### PR TITLE
fix(ci): resolve pre-existing stylua, prettier, and LuaLS failures

### DIFF
--- a/lua/canola/adapters/ssh/connection.lua
+++ b/lua/canola/adapters/ssh/connection.lua
@@ -306,7 +306,7 @@ function SSHConnection:_consume()
         -- HACK: Sleep briefly to help reduce stderr/stdout interleaving.
         -- I want to find a way to flush the stderr before the echo DONE, but haven't yet.
         -- This was causing issues when ls directory that doesn't exist (b/c ls prints error)
-        'echo "===BEGIN==="; ' .. cmd.cmd .. '; CODE=$?; sleep .01; echo "===DONE($CODE)===\r'
+        'echo "===BEGIN==="; ' .. cmd.cmd .. '; CODE=$?; sleep .01; echo "===DONE($CODE)==="\r'
       )
     end
   end


### PR DESCRIPTION
## Problem

Three pre-existing CI failures were masked because `stylua` ran first and exited early. Once `stylua` was fixed, `prettier` and `lua-language-server` also failed. The local `scripts/ci.sh` also ran LuaLS against the entire repo without library context, producing 739 spurious warnings.

## Solution

Collapse a multiline string concat in `lua/canola/adapters/ssh/connection.lua` to satisfy `stylua`. Run `prettier --write` on `.github/workflows/quality.yaml` and `README.md`. Update `scripts/ci.sh` to check only `lua/` with the canola library injected at runtime (matching `nvim-typecheck-action`), switch to `--checklevel=Error`, and add `vim` global plus `${3rd}/busted/library` to `.luarc.json`.