### PR TITLE
feat: add recursive delete guard to SSH, S3, and FTP adapters

### DIFF
--- a/doc/canola-collection.txt
+++ b/doc/canola-collection.txt
@@ -32,6 +32,7 @@ canola-ssh                                                        *canola-ssh*
     vim.g.canola_ssh = {
       extra_args = {},
       border = nil,
+      recursive = false,
       hosts = {
         -- ["nas.local"] = { extra_args = { "-O" } },
       },
@@ -40,6 +41,9 @@ canola-ssh                                                        *canola-ssh*
   extra_args    Extra arguments appended to scp commands.
   border        Border for the SSH terminal window. When nil, inherits
                 the global `border` from `vim.g.canola`.
+  recursive     When true, allow deleting directories. When false (default),
+                directory deletes return an error. Overrides
+                `vim.g.canola.delete.recursive` for this adapter.
   hosts         Per-host overrides. Keys are hostnames as they appear in
                 the URL. Each entry supports `extra_args` which is
                 appended after the global `extra_args`.
@@ -52,12 +56,16 @@ canola-s3                                                          *canola-s3*
   >lua
     vim.g.canola_s3 = {
       extra_args = {},
+      recursive = false,
       buckets = {
         -- ["my-r2"] = { extra_args = { "--endpoint-url", "..." } },
       },
     }
 <
   extra_args    Extra arguments appended to `aws s3` commands.
+  recursive     When true, allow deleting prefixes and buckets. When false
+                (default), directory deletes return an error. Overrides
+                `vim.g.canola.delete.recursive` for this adapter.
   buckets       Per-bucket overrides. Keys are bucket names. Each entry
                 supports `extra_args` appended after the global value.
 
@@ -69,12 +77,16 @@ canola-ftp                                                        *canola-ftp*
   >lua
     vim.g.canola_ftp = {
       extra_args = {},
+      recursive = false,
       hosts = {
         -- ["ftp.internal.com"] = { extra_args = { "--insecure" } },
       },
     }
 <
   extra_args    Extra arguments appended to curl commands.
+  recursive     When true, allow deleting directories. When false (default),
+                directory deletes return an error. Overrides
+                `vim.g.canola.delete.recursive` for this adapter.
   hosts         Per-host overrides. Keys are hostnames as they appear in
                 the URL. Each entry supports `extra_args` appended after
                 the global value.

--- a/lua/canola/adapters/ftp.lua
+++ b/lua/canola/adapters/ftp.lua
@@ -564,6 +564,16 @@ M.perform_action = function(action, cb)
     local res = M.parse_url(action.url)
     local ftp_path = ftp_abs_path(res)
     if action.entry_type == 'directory' then
+      local cfg = vim.g.canola_ftp or {}
+      local recursive = cfg.recursive
+      if recursive == nil then
+        recursive = ((vim.g.canola or {}).delete or {}).recursive
+      end
+      if not recursive then
+        return cb(
+          'Recursive delete is disabled. Set `recursive = true` in `vim.g.canola_ftp` or `vim.g.canola.delete` to allow deleting FTP directories.'
+        )
+      end
       ftpcmd(res, {
         'def rmtree(f, p):',
         '  try:',

--- a/lua/canola/adapters/s3.lua
+++ b/lua/canola/adapters/s3.lua
@@ -239,11 +239,24 @@ M.perform_action = function(action, cb)
   elseif action.type == 'delete' then
     local res = M.parse_url(action.url)
     local bucket = is_bucket(res)
-
-    if action.entry_type == 'directory' and bucket then
-      s3fs.rb(url_to_s3(res, true), cb)
-    elseif action.entry_type == 'directory' or action.entry_type == 'file' then
-      s3fs.rm(url_to_s3(res, is_folder), is_folder, cb)
+    if action.entry_type == 'directory' then
+      local cfg = vim.g.canola_s3 or {}
+      local recursive = cfg.recursive
+      if recursive == nil then
+        recursive = ((vim.g.canola or {}).delete or {}).recursive
+      end
+      if not recursive then
+        return cb(
+          'Recursive delete is disabled. Set `recursive = true` in `vim.g.canola_s3` or `vim.g.canola.delete` to allow deleting S3 prefixes and buckets.'
+        )
+      end
+      if bucket then
+        s3fs.rb(url_to_s3(res, true), true, cb)
+      else
+        s3fs.rm(url_to_s3(res, is_folder), is_folder, cb)
+      end
+    elseif action.entry_type == 'file' then
+      s3fs.rm(url_to_s3(res, false), false, cb)
     else
       cb(string.format('Bad entry type on s3 delete action: %s', action.entry_type))
     end

--- a/lua/canola/adapters/s3/s3fs.lua
+++ b/lua/canola/adapters/s3/s3fs.lua
@@ -119,9 +119,14 @@ end
 
 --- Remove bucket
 ---@param bucket string
+---@param force boolean
 ---@param callback fun(err: nil|string)
-function M.rb(bucket, callback)
-  local cmd = create_s3_command({ 'rb', bucket })
+function M.rb(bucket, force, callback)
+  local main_cmd = { 'rb', bucket }
+  if force then
+    table.insert(main_cmd, '--force')
+  end
+  local cmd = create_s3_command(main_cmd)
   shell.run(cmd, callback)
 end
 

--- a/lua/canola/adapters/ssh.lua
+++ b/lua/canola/adapters/ssh.lua
@@ -348,6 +348,18 @@ M.perform_action = function(action, cb)
   elseif action.type == 'delete' then
     local res = M.parse_url(action.url)
     local conn = get_connection(action.url)
+    if action.entry_type == 'directory' then
+      local cfg = vim.g.canola_ssh or {}
+      local recursive = cfg.recursive
+      if recursive == nil then
+        recursive = ((vim.g.canola or {}).delete or {}).recursive
+      end
+      if not recursive then
+        return cb(
+          'Recursive delete is disabled. Set `recursive = true` in `vim.g.canola_ssh` or `vim.g.canola.delete` to allow deleting directories over SSH.'
+        )
+      end
+    end
     conn:rm(res.path, cb)
   elseif action.type == 'move' then
     local src_adapter = assert(config.get_adapter_by_scheme(action.src_url))


### PR DESCRIPTION
## Problem

Deleting a directory over SSH (`rm -rf`), S3 (`rm --recursive` or `rb --force`), or FTP (`rmtree`) is irreversible with no safeguard.

## Solution

Gate directory deletes behind a `recursive` flag. Global default in `vim.g.canola.delete.recursive` (false), with per-adapter override. Closes #11.