### PR TITLE
fix(trash/windows): don't overwrite file entries with virtual dirs in show_all_files mode

### DIFF
--- a/lua/canola/adapters/trash/windows.lua
+++ b/lua/canola/adapters/trash/windows.lua
@@ -106,7 +106,7 @@ M.list = function(url, column_defs, cb)
             display_name = entry.Name,
           }
         end
-        if path ~= parent and (show_all_files or fs.is_subpath(path, parent)) then
+        if path ~= parent and not show_all_files and fs.is_subpath(path, parent) then
           local name = parent:sub(path:len() + 1)
           local next_par = vim.fs.dirname(name)
           while next_par ~= '.' do


### PR DESCRIPTION
## Problem

In `list()`, when `show_all_files = true` and `path ~= parent`, both branches of the `tbl_map` callback ran — the first creating the real file entry, the second overwriting it with a virtual directory entry.

## Solution

Remove `show_all_files` from the second branch's condition. Closes #10.