### PR TITLE
refactor(canola-git): drop `setup()` and auto-init from plugin file

### DIFF
--- a/lua/canola-git/init.lua
+++ b/lua/canola-git/init.lua
@@ -2,7 +2,6 @@ local M = {}
 
 M._cache = {}
 local pending = {}
-local registered = false
 
 local STAT_HL = {
   ['?'] = 'DiagnosticHint',
@@ -187,12 +186,7 @@ local function is_hidden(name, bufnr)
   return false
 end
 
-M.setup = function()
-  if registered then
-    return
-  end
-  registered = true
-
+M._init = function()
   require('canola.columns').register('git_status', {
     render = function(entry, conf, bufnr)
       local name = entry[require('canola.constants').FIELD_NAME]
@@ -212,9 +206,6 @@ M.setup = function()
       local c = xy:sub(1, 1) ~= ' ' and xy:sub(1, 1) or xy:sub(2, 2)
       return { text, STAT_HL[c] or 'Normal' }
     end,
-    parse = function(line, conf)
-      return line:match('^(%S+)%s+(.*)$')
-    end,
   })
 
   local cfg = get_config()
@@ -222,10 +213,8 @@ M.setup = function()
     return
   end
 
-  vim.schedule(function()
-    require('canola').set_is_hidden_file(function(name, bufnr, _entry)
-      return is_hidden(name, bufnr)
-    end)
+  require('canola').set_is_hidden_file(function(name, bufnr, _entry)
+    return is_hidden(name, bufnr)
   end)
 
   vim.api.nvim_create_autocmd('User', {

--- a/plugin/canola-collection.lua
+++ b/plugin/canola-collection.lua
@@ -13,6 +13,8 @@ if vim.fn.has('nvim-0.12') == 0 then
   canola.register_adapter('canola-sss://', 's3')
 end
 
+require('canola-git')._init()
+
 vim.api.nvim_create_autocmd('BufNew', {
   pattern = 'scp://*',
   once = true,

--- a/spec/canola_git_spec.lua
+++ b/spec/canola_git_spec.lua
@@ -62,7 +62,7 @@ describe('canola-git', function()
     vim.schedule = original_schedule
   end)
 
-  describe('setup()', function()
+  describe('_init()', function()
     it('registers is_hidden_file override', function()
       local registered_fn = nil
       local canola_mock = make_canola_mock(nil)
@@ -71,24 +71,11 @@ describe('canola-git', function()
       end
       inject_mocks(canola_mock, make_git_mock(nil), make_view_mock())
       canola_git = require('canola-git')
-      canola_git.setup()
+      canola_git._init()
       assert.is_function(registered_fn)
     end)
 
-    it('is idempotent when called twice', function()
-      local call_count = 0
-      local canola_mock = make_canola_mock(nil)
-      canola_mock.set_is_hidden_file = function(_fn)
-        call_count = call_count + 1
-      end
-      inject_mocks(canola_mock, make_git_mock(nil), make_view_mock())
-      canola_git = require('canola-git')
-      canola_git.setup()
-      canola_git.setup()
-      assert.equals(1, call_count)
-    end)
-
-    it('skips registration when enabled = false', function()
+    it('skips is_hidden_file when enabled = false', function()
       vim.g.canola_git = { enabled = false }
       local call_count = 0
       local canola_mock = make_canola_mock(nil)
@@ -97,7 +84,7 @@ describe('canola-git', function()
       end
       inject_mocks(canola_mock, make_git_mock(nil), make_view_mock())
       canola_git = require('canola-git')
-      canola_git.setup()
+      canola_git._init()
       assert.equals(0, call_count)
     end)
   end)
@@ -112,7 +99,7 @@ describe('canola-git', function()
       end
       inject_mocks(canola_mock, make_git_mock(nil), make_view_mock())
       canola_git = require('canola-git')
-      canola_git.setup()
+      canola_git._init()
     end)
 
     it('hides dotfiles by default before cache is populated', function()
@@ -134,7 +121,7 @@ describe('canola-git', function()
       end
       inject_mocks(canola_mock, make_git_mock(nil), make_view_mock())
       canola_git = require('canola-git')
-      canola_git.setup()
+      canola_git._init()
     end)
 
     it('hides dotfiles when get_current_dir returns nil', function()
@@ -157,7 +144,7 @@ describe('canola-git', function()
       end
       inject_mocks(canola_mock, make_git_mock('/repo'), make_view_mock())
       canola_git = require('canola-git')
-      canola_git.setup()
+      canola_git._init()
     end)
 
     it('shows tracked dotfiles', function()


### PR DESCRIPTION
## Problem

`canola-git` exposed a `setup()` function that users had to call manually,
contradicting canola's design principle of self-initializing from `vim.g.*`
config without explicit setup calls.

## Solution

Replace `M.setup()` with `M._init()` called automatically from
`plugin/canola-collection.lua`. Remove the idempotency guard, the
`vim.schedule` wrapper around `set_is_hidden_file`, and the bogus `parse`
function from the column registration.