### PR TITLE
fix(canola-git): invalidate cache on mutations and focus

### DIFF
--- a/lua/canola-git/init.lua
+++ b/lua/canola-git/init.lua
@@ -232,6 +232,28 @@ M._init = function()
       populate_cache(dir)
     end,
   })
+
+  local function invalidate_all()
+    M._cache = {}
+    pending = {}
+    for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+      if vim.bo[bufnr].filetype == 'canola' then
+        local dir = require('canola').get_current_dir(bufnr)
+        if dir then
+          populate_cache(dir)
+        end
+      end
+    end
+  end
+
+  vim.api.nvim_create_autocmd('User', {
+    pattern = 'CanolaMutationComplete',
+    callback = invalidate_all,
+  })
+
+  vim.api.nvim_create_autocmd('FocusGained', {
+    callback = invalidate_all,
+  })
 end
 
 return M


### PR DESCRIPTION
## Problem

Git status cache was frozen after the first directory load. Staging,
committing, or editing files externally never updated the displayed
status.

## Solution

Clear the cache and re-populate visible canola buffers on
`CanolaMutationComplete` and `FocusGained` events.