### PR TITLE
feat(canola-git): cache invalidation and public `invalidate()` API

### DIFF
--- a/doc/canola-collection.txt
+++ b/doc/canola-collection.txt
@@ -107,9 +107,8 @@ canola-trash                                                    *canola-trash*
 canola-git                                                        *canola-git*
   Git-aware hidden file filtering for local directories. Replaces the default
   dotfile filter with one that respects the git index: tracked dotfiles are
-  shown, untracked dotfiles and ignored files are hidden.
-
-  Call `require('canola-git').setup()` after `vim.g.canola_git` is set.
+  shown, untracked dotfiles and ignored files are hidden. Activates
+  automatically when canola-collection is loaded.
 
   Configuration:                                           *vim.g.canola_git*
   >lua
@@ -145,10 +144,30 @@ canola-git                                                        *canola-git*
   queried when the column is present in the columns list.
   >lua
     vim.g.canola = {
-      columns = { 'icon', 'git_status', 'size', 'mtime' },
+      columns = { 'git_status', 'icon' },
     }
 <
   The column is a read-only display; it does not affect mutations.
+
+  Cache invalidation ~
+  Git status is cached per directory. The cache is automatically refreshed
+  on `CanolaMutationComplete` (after file operations via canola),
+  `FocusGained` (returning to nvim after external changes), and `BufEnter`
+  (re-entering a canola buffer). To trigger a manual refresh from a custom
+  event or keymap, call `invalidate()`:
+                                              *canola-git.invalidate()*
+  >lua
+    require('canola-git').invalidate()
+<
+  This clears the entire cache and re-queries git for all visible canola
+  buffers. For example, to also refresh after `:!` shell commands:
+  >lua
+    vim.api.nvim_create_autocmd('ShellCmdPost', {
+      callback = function()
+        require('canola-git').invalidate()
+      end,
+    })
+<
 
   Hidden file fallback ~
   In directories that are not inside a git repository, canola-git falls back

--- a/lua/canola-git/init.lua
+++ b/lua/canola-git/init.lua
@@ -233,27 +233,46 @@ M._init = function()
     end,
   })
 
-  local function invalidate_all()
-    M._cache = {}
-    pending = {}
-    for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
-      if vim.bo[bufnr].filetype == 'canola' then
-        local dir = require('canola').get_current_dir(bufnr)
-        if dir then
-          populate_cache(dir)
-        end
-      end
-    end
-  end
-
   vim.api.nvim_create_autocmd('User', {
     pattern = 'CanolaMutationComplete',
-    callback = invalidate_all,
+    callback = function()
+      M.invalidate()
+    end,
   })
 
   vim.api.nvim_create_autocmd('FocusGained', {
-    callback = invalidate_all,
+    callback = function()
+      M.invalidate()
+    end,
   })
+
+  vim.api.nvim_create_autocmd('BufEnter', {
+    callback = function(args)
+      if vim.bo[args.buf].filetype ~= 'canola' then
+        return
+      end
+      local ok, dir = pcall(require('canola').get_current_dir, args.buf)
+      if not ok or not dir then
+        return
+      end
+      M._cache[dir] = nil
+      pending[dir] = nil
+      populate_cache(dir)
+    end,
+  })
+end
+
+M.invalidate = function()
+  M._cache = {}
+  pending = {}
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.bo[bufnr].filetype == 'canola' then
+      local ok, dir = pcall(require('canola').get_current_dir, bufnr)
+      if ok and dir then
+        populate_cache(dir)
+      end
+    end
+  end
 end
 
 return M


### PR DESCRIPTION
## Problem

Git status cache was frozen after first directory load. Staging, committing,
or editing files externally never updated the displayed status. No public API
existed for users to trigger cache refresh from custom events.

## Solution

- Refresh per-directory cache on `BufEnter` (re-entering a canola buffer)
- Refresh all caches on `CanolaMutationComplete` and `FocusGained`
- Expose `require('canola-git').invalidate()` for custom event hooks
- Document cache invalidation behavior and `invalidate()` API in helpdoc