### PR TITLE
build: separate ci devshell to avoid overriding system neovim

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,20 @@
         default = pkgs.mkShell {
           packages = [
             pkgs.prettier
+            pkgs.stylua
+            pkgs.selene
+            pkgs.lua-language-server
+            vimdoc-language-server.packages.${pkgs.system}.default
+            (pkgs.luajit.withPackages (ps: [
+              ps.busted
+              ps.nlua
+            ]))
+          ];
+        };
+
+        ci = pkgs.mkShell {
+          packages = [
+            pkgs.prettier
             pkgs.neovim
             pkgs.stylua
             pkgs.selene

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 set -eu
 
-nix develop --command stylua --check .
-git ls-files '*.lua' | xargs nix develop --command selene --display-style quiet
-nix develop --command prettier --check .
+nix develop .#ci --command stylua --check .
+git ls-files '*.lua' | xargs nix develop .#ci --command selene --display-style quiet
+nix develop .#ci --command prettier --check .
 nix fmt
 git diff --exit-code -- '*.nix'
 CANOLA_LIB=$(test -d _canola && echo _canola || echo "$HOME/dev/canola.nvim")/lua
@@ -14,8 +14,8 @@ with open('.luarc.json') as f: cfg = json.load(f)
 cfg.setdefault('workspace', {}).setdefault('library', []).append(sys.argv[1])
 print(json.dumps(cfg))
 " "$CANOLA_LIB" > "$LUARC_TMP"
-nix develop --command lua-language-server --check lua --checklevel=Error \
+nix develop .#ci --command lua-language-server --check lua --checklevel=Error \
   --configpath="$LUARC_TMP"
 rm -f "$LUARC_TMP"
-nix develop --command vimdoc-language-server check doc/ --no-runtime-tags
-nix develop --command busted
+nix develop .#ci --command vimdoc-language-server check doc/ --no-runtime-tags
+nix develop .#ci --command busted


### PR DESCRIPTION
## Problem

The default devshell included `pkgs.neovim` which overrode the user's
system neovim (e.g. nightly) on PATH when entering the shell.

## Solution

Move `pkgs.neovim` to a dedicated `ci` devshell. The default shell no
longer includes neovim. `scripts/ci.sh` uses `nix develop .#ci` for all
commands.