### PR TITLE
fix(canola-git): guard against deleted directories

### DIFF
--- a/lua/canola-git/init.lua
+++ b/lua/canola-git/init.lua
@@ -69,6 +69,10 @@ local function populate_cache(dir)
   if pending[dir] then
     return
   end
+  if not vim.uv.fs_stat(dir) then
+    M._cache[dir] = false
+    return
+  end
   pending[dir] = true
 
   local git = require('canola.git')


### PR DESCRIPTION
## Problem

Refocusing nvim after an external process deleted a directory caused
`vim.system` to error with ENOENT in `populate_cache`.

## Solution

Check `vim.uv.fs_stat(dir)` before spawning git processes.