### PR TITLE
feat: add LuaCATS type annotations across all modules

### DIFF
--- a/lua/canola-git/init.lua
+++ b/lua/canola-git/init.lua
@@ -1,8 +1,26 @@
+---@class (exact) canola.git.Config
+---@field enabled boolean
+---@field show {untracked: boolean, ignored: boolean}
+---@field format 'compact'|'porcelain'|'symbol'
+
+---@class (exact) canola.git.CacheEntry
+---@field ignored table<string, boolean>
+---@field tracked table<string, boolean>
+---@field status table<string, string>
+
+---@class (exact) canola.git.StatusResult
+---@field status string
+---@field char string
+---@field hl string
+
 local M = {}
 
+---@type table<string, canola.git.CacheEntry|false>
 M._cache = {}
+---@type table<string, true>
 local pending = {}
 
+---@type table<string, string>
 local STAT_HL = {
   ['?'] = 'DiagnosticHint',
   ['!'] = 'Comment',
@@ -14,6 +32,7 @@ local STAT_HL = {
   ['U'] = 'DiagnosticError',
 }
 
+---@type table<string, integer>
 local STATUS_PRIORITY = {
   ['U'] = 6,
   ['D'] = 5,
@@ -25,6 +44,7 @@ local STATUS_PRIORITY = {
   ['!'] = 0,
 }
 
+---@return canola.git.Config
 local function get_config()
   return vim.tbl_deep_extend('keep', vim.g.canola_git or {}, {
     enabled = true,
@@ -33,15 +53,22 @@ local function get_config()
   })
 end
 
+---@param name string
+---@return boolean
 local function is_dotfile(name)
   return name:match('^%.') ~= nil
 end
 
+---@param xy string
+---@return string
 local function status_char(xy)
   local x, y = xy:sub(1, 1), xy:sub(2, 2)
   return x ~= ' ' and x or y
 end
 
+---@param xy string?
+---@param fmt string
+---@return string?
 local function format_status(xy, fmt)
   if not xy then
     return nil
@@ -60,11 +87,14 @@ local function format_status(xy, fmt)
   end
 end
 
+---@param path string
+---@return string
 local function first_component(path)
   local slash = path:find('/', 1, true)
   return slash and path:sub(1, slash - 1) or path
 end
 
+---@param dir string
 local function populate_cache(dir)
   if pending[dir] then
     return
@@ -83,9 +113,12 @@ local function populate_cache(dir)
     return
   end
 
-  local ignored = nil
-  local tracked = nil
-  local status = nil
+  ---@type table<string, boolean>
+  local ignored
+  ---@type table<string, boolean>
+  local tracked
+  ---@type table<string, string>
+  local status
   local remaining = 3
 
   local function on_query_done()
@@ -167,6 +200,9 @@ local function populate_cache(dir)
   )
 end
 
+---@param name string
+---@param bufnr integer
+---@return boolean
 local function is_hidden(name, bufnr)
   if name == '..' then
     return false
@@ -282,6 +318,9 @@ M._init = function()
   })
 end
 
+---@param dir string
+---@param name string
+---@return canola.git.StatusResult?
 M.get_status = function(dir, name)
   local cache = M._cache[dir]
   if not cache or cache == false or not cache.status then

--- a/lua/canola/adapters/ftp.lua
+++ b/lua/canola/adapters/ftp.lua
@@ -203,6 +203,7 @@ local function url_hosts_equal(url1, url2)
   return url1.host == url2.host and url1.port == url2.port and url1.user == url2.user
 end
 
+---@type table<string, integer>
 local month_map = {
   Jan = 1,
   Feb = 2,
@@ -310,6 +311,7 @@ local function parse_iis_list_line(line)
 end
 
 local ftp_columns = {}
+---@type canola.ColumnDefinition
 ftp_columns.size = {
   render = function(entry, conf)
     local meta = entry[FIELD_META]
@@ -344,6 +346,7 @@ ftp_columns.size = {
   end,
 }
 
+---@type canola.ColumnDefinition
 ftp_columns.mtime = {
   render = function(entry, conf)
     local meta = entry[FIELD_META]
@@ -367,6 +370,7 @@ ftp_columns.mtime = {
   end,
 }
 
+---@type canola.ColumnDefinition
 ftp_columns.permissions = {
   render = function(entry, conf)
     local meta = entry[FIELD_META]
@@ -408,6 +412,7 @@ ftp_columns.permissions = {
   end,
 }
 
+---@type canola.ColumnDefinition
 ftp_columns.owner = {
   render = function(entry, conf)
     local meta = entry[FIELD_META]
@@ -422,6 +427,7 @@ ftp_columns.owner = {
   end,
 }
 
+---@type canola.ColumnDefinition
 ftp_columns.group = {
   render = function(entry, conf)
     local meta = entry[FIELD_META]
@@ -658,6 +664,7 @@ M.perform_action = function(action, cb)
   end
 end
 
+---@type table<string, string>
 M.supported_cross_adapter_actions = { files = 'copy' }
 
 ---@param bufnr integer

--- a/lua/canola/adapters/s3.lua
+++ b/lua/canola/adapters/s3.lua
@@ -80,6 +80,7 @@ local function is_bucket(url)
 end
 
 local s3_columns = {}
+---@type canola.ColumnDefinition
 s3_columns.size = {
   render = function(entry, conf)
     local meta = entry[FIELD_META]
@@ -114,6 +115,7 @@ s3_columns.size = {
   end,
 }
 
+---@type canola.ColumnDefinition
 s3_columns.birthtime = {
   render = function(entry, conf)
     local meta = entry[FIELD_META]
@@ -335,6 +337,7 @@ M.perform_action = function(action, cb)
   end
 end
 
+---@type table<string, string>
 M.supported_cross_adapter_actions = { files = 'move' }
 
 ---@param bufnr integer

--- a/lua/canola/adapters/s3/s3fs.lua
+++ b/lua/canola/adapters/s3/s3fs.lua
@@ -42,8 +42,8 @@ local function parse_ls_line_file(line)
   return name, type, meta
 end
 
----@param cmd string[] cmd and flags
----@return string[] Shell command to run
+---@param cmd string[]
+---@return string[]
 local function create_s3_command(cmd)
   local bucket
   for _, arg in ipairs(cmd) do

--- a/lua/canola/adapters/ssh.lua
+++ b/lua/canola/adapters/ssh.lua
@@ -111,6 +111,7 @@ local function url_hosts_equal(url1, url2)
   return url1.host == url2.host and url1.port == url2.port and url1.user == url2.user
 end
 
+---@type table<string, canola.sshFs>
 local _connections = {}
 ---@param url string
 ---@param allow_retry nil|boolean
@@ -129,6 +130,7 @@ local function get_connection(url, allow_retry)
 end
 
 local ssh_columns = {}
+---@type canola.ColumnDefinition
 ssh_columns.permissions = {
   render = function(entry, conf)
     local meta = entry[FIELD_META]
@@ -162,6 +164,7 @@ ssh_columns.permissions = {
   end,
 }
 
+---@type canola.ColumnDefinition
 ssh_columns.owner = {
   render = function(entry, conf)
     local meta = entry[FIELD_META]
@@ -176,6 +179,7 @@ ssh_columns.owner = {
   end,
 }
 
+---@type canola.ColumnDefinition
 ssh_columns.group = {
   render = function(entry, conf)
     local meta = entry[FIELD_META]
@@ -190,6 +194,7 @@ ssh_columns.group = {
   end,
 }
 
+---@type canola.ColumnDefinition
 ssh_columns.size = {
   render = function(entry, conf)
     local meta = entry[FIELD_META]
@@ -424,6 +429,7 @@ M.perform_action = function(action, cb)
   end
 end
 
+---@type table<string, string>
 M.supported_cross_adapter_actions = { files = 'copy' }
 
 ---@param bufnr integer

--- a/lua/canola/adapters/ssh/connection.lua
+++ b/lua/canola/adapters/ssh/connection.lua
@@ -20,6 +20,9 @@ local util = require('canola.util')
 ---@field private _stdout string[]
 local SSHConnection = {}
 
+---@param agg string[]
+---@param output string[]
+---@return integer
 local function output_extend(agg, output)
   local start = #agg
   if vim.tbl_isempty(agg) then
@@ -193,6 +196,7 @@ function SSHConnection:_set_connection_error(err)
   end
 end
 
+---@param start_i integer
 function SSHConnection:_handle_output(start_i)
   if not self.connected then
     for i = start_i, #self._stdout - 1 do

--- a/lua/canola/adapters/ssh/sshfs.lua
+++ b/lua/canola/adapters/ssh/sshfs.lua
@@ -12,6 +12,7 @@ local SSHFS = {}
 local FIELD_TYPE = constants.FIELD_TYPE
 local FIELD_META = constants.FIELD_META
 
+---@type table<string, canola.EntryType>
 local typechar_map = {
   l = 'link',
   d = 'directory',
@@ -85,6 +86,7 @@ function SSHFS.new(url)
   })
 end
 
+---@return string?
 function SSHFS:get_connection_error()
   return self.conn.connection_error
 end
@@ -101,6 +103,8 @@ function SSHFS:open_terminal()
   self.conn:open_terminal()
 end
 
+---@param path string
+---@param callback fun(err?: string, abspath?: string)
 function SSHFS:realpath(path, callback)
   local cmd = string.format(
     'if ! readlink -f "%s" 2>/dev/null; then case "%s" in /*) echo "%s";; *) echo "$PWD/%s";; esac; fi',
@@ -140,6 +144,7 @@ function SSHFS:realpath(path, callback)
   end)
 end
 
+---@type table<string, table>
 local dir_meta = {}
 
 ---@param url string
@@ -253,10 +258,13 @@ function SSHFS:cp(src, dest, callback)
   self.conn:run(string.format('cp -r %s %s', shellescape(src), shellescape(dest)), callback)
 end
 
+---@param url string
+---@return table?
 function SSHFS:get_dir_meta(url)
   return dir_meta[url]
 end
 
+---@return {user?: string, groups?: string[]}
 function SSHFS:get_meta()
   return self.conn.meta
 end

--- a/lua/canola/adapters/trash/freedesktop.lua
+++ b/lua/canola/adapters/trash/freedesktop.lua
@@ -12,6 +12,7 @@ local FIELD_META = constants.FIELD_META
 
 local M = {}
 
+---@param path string
 local function ensure_trash_dir(path)
   local mode = 448 -- 0700
   fs.mkdirp(fs.join(path, 'info'), mode)
@@ -345,12 +346,14 @@ end
 
 local file_columns = {}
 
+---@type string
 local current_year
 -- Make sure we run this import-time effect in the main loop (mostly for tests)
 vim.schedule(function()
   current_year = vim.fn.strftime('%Y')
 end)
 
+---@type canola.ColumnDefinition
 file_columns.mtime = {
   render = function(entry, conf)
     local meta = entry[FIELD_META]
@@ -407,6 +410,7 @@ M.get_column = function(name)
   return file_columns[name]
 end
 
+---@type table<string, string>
 M.supported_cross_adapter_actions = { files = 'move' }
 
 ---@param action canola.Action

--- a/lua/canola/adapters/trash/mac.lua
+++ b/lua/canola/adapters/trash/mac.lua
@@ -8,6 +8,7 @@ local uv = vim.uv or vim.loop
 
 local M = {}
 
+---@param path string
 local function touch_dir(path)
   uv.fs_mkdir(path, 448) -- 0700
 end
@@ -153,6 +154,7 @@ M.get_column = function(name)
   return nil
 end
 
+---@type table<string, string>
 M.supported_cross_adapter_actions = { files = 'move' }
 
 ---@param action canola.Action

--- a/lua/canola/adapters/trash/windows.lua
+++ b/lua/canola/adapters/trash/windows.lua
@@ -129,6 +129,7 @@ M.is_modifiable = function(_bufnr)
   return true
 end
 
+---@type string
 local current_year
 -- Make sure we run this import-time effect in the main loop (mostly for tests)
 vim.schedule(function()
@@ -136,6 +137,7 @@ vim.schedule(function()
 end)
 
 local file_columns = {}
+---@type canola.ColumnDefinition
 file_columns.mtime = {
   render = function(entry, conf)
     local meta = entry[FIELD_META]
@@ -401,6 +403,7 @@ M.perform_action = function(action, cb)
   end
 end
 
+---@type table<string, string>
 M.supported_cross_adapter_actions = { files = 'move' }
 
 ---@param path string

--- a/lua/canola/adapters/trash/windows/powershell-connection.lua
+++ b/lua/canola/adapters/trash/windows/powershell-connection.lua
@@ -26,6 +26,7 @@ function PowershellConnection.new(init_command)
   return self
 end
 
+---@private
 ---@param init_command? string
 function PowershellConnection:_init(init_command)
   -- For some reason beyond my understanding, at least one of the following
@@ -94,6 +95,7 @@ function PowershellConnection:run(command, cb)
   end
 end
 
+---@private
 function PowershellConnection:_consume()
   if not vim.tbl_isempty(self.commands) then
     local cmd = self.commands[1]

--- a/lua/resession/extensions/canola.lua
+++ b/lua/resession/extensions/canola.lua
@@ -1,15 +1,22 @@
 local M = {}
 
+---@param winid integer
+---@param bufnr integer
+---@return boolean
 M.is_win_supported = function(winid, bufnr)
   return vim.bo[bufnr].filetype == 'canola'
 end
 
+---@param winid integer
+---@return {bufname: string}
 M.save_win = function(winid)
   local bufnr = vim.api.nvim_win_get_buf(winid)
   local bufname = vim.api.nvim_buf_get_name(bufnr)
   return { bufname = bufname }
 end
 
+---@param winid integer
+---@param config {bufname: string}
 M.load_win = function(winid, config)
   require('canola').open(config.bufname)
 end


### PR DESCRIPTION
## Problem

The codebase lacked type annotations on most local functions, module tables, and column definitions, limiting IDE support and static analysis coverage.

## Solution

Add `@class`, `@field`, `@param`, `@return`, `@type`, and `@private` annotations to all 12 Lua source files. Introduce three new classes (`canola.git.Config`, `canola.git.CacheEntry`, `canola.git.StatusResult`) in `canola-git/init.lua` and type all column tables with `canola.ColumnDefinition` across adapters.