### PR TITLE
feat(canola-git): fix subdirectory signs, add watcher and porcelain highlights

### DIFF
--- a/lua/canola-git/init.lua
+++ b/lua/canola-git/init.lua
@@ -12,6 +12,8 @@
 ---@field status string
 ---@field char string
 ---@field hl string
+---@field index string?
+---@field worktree string?
 
 local M = {}
 
@@ -19,6 +21,12 @@ local M = {}
 M._cache = {}
 ---@type table<string, true>
 local pending = {}
+---@type table<string, number>
+local cache_time = {}
+---@type table<string, any>
+local watchers = {}
+---@type table<string, any>
+local debounce_timers = {}
 
 ---@type table<string, string>
 local STAT_HL = {
@@ -94,6 +102,91 @@ local function first_component(path)
   return slash and path:sub(1, slash - 1) or path
 end
 
+---@param root string
+local function start_watcher(root)
+  if watchers[root] then
+    return
+  end
+  local git_dir = root .. '/.git'
+  local stat = vim.uv.fs_stat(git_dir)
+  if not stat then
+    return
+  end
+  local watch_path
+  if stat.type == 'file' then
+    local f = io.open(git_dir, 'r')
+    if not f then
+      return
+    end
+    local line = f:read('*l')
+    f:close()
+    local target = line and line:match('^gitdir: (.+)')
+    if not target then
+      return
+    end
+    if not target:match('^/') then
+      target = root .. '/' .. target
+    end
+    watch_path = target
+  else
+    watch_path = git_dir
+  end
+  local handle = vim.uv.new_fs_event()
+  if not handle then
+    return
+  end
+  handle:start(
+    watch_path,
+    {},
+    vim.schedule_wrap(function(err, filename)
+      if err then
+        return
+      end
+      if filename ~= 'index' and filename ~= 'HEAD' then
+        return
+      end
+      if debounce_timers[root] then
+        debounce_timers[root]:stop()
+      end
+      local timer = debounce_timers[root] or vim.uv.new_timer()
+      if not timer then
+        return
+      end
+      debounce_timers[root] = timer
+      timer:start(
+        300,
+        0,
+        vim.schedule_wrap(function()
+          timer:stop()
+          for _, winid in ipairs(vim.api.nvim_list_wins()) do
+            if vim.api.nvim_win_is_valid(winid) then
+              local bufnr = vim.api.nvim_win_get_buf(winid)
+              if vim.bo[bufnr].filetype == 'canola' then
+                M.invalidate()
+                return
+              end
+            end
+          end
+        end)
+      )
+    end)
+  )
+  watchers[root] = handle
+end
+
+local function stop_watchers()
+  for _, handle in pairs(watchers) do
+    handle:stop()
+    handle:close()
+  end
+  watchers = {}
+  for _, timer in pairs(debounce_timers) do
+    timer:stop()
+    timer:close()
+  end
+  debounce_timers = {}
+end
+
 ---@param dir string
 local function populate_cache(dir)
   if pending[dir] then
@@ -112,6 +205,11 @@ local function populate_cache(dir)
     pending[dir] = nil
     return
   end
+  pcall(start_watcher, root)
+  local relprefix = dir:sub(#root + 1):gsub('^/', '')
+  if relprefix ~= '' and relprefix:sub(-1) ~= '/' then
+    relprefix = relprefix .. '/'
+  end
 
   ---@type table<string, boolean>
   local ignored
@@ -127,6 +225,7 @@ local function populate_cache(dir)
       return
     end
     M._cache[dir] = { ignored = ignored, tracked = tracked, status = status }
+    cache_time[dir] = vim.uv.now()
     pending[dir] = nil
     require('canola.view').rerender_all_oil_buffers({ refetch = false })
   end
@@ -179,6 +278,9 @@ local function populate_cache(dir)
               path = path:sub(arrow + 4)
             end
             path = path:gsub('/$', '')
+            if relprefix ~= '' and path:sub(1, #relprefix) == relprefix then
+              path = path:sub(#relprefix + 1)
+            end
             local name = first_component(path)
             if name ~= '' then
               local existing = status[name]
@@ -253,9 +355,16 @@ M._init = function()
         return nil
       end
       local xy = cache.status[name]
-      local text = format_status(xy, get_config().format)
+      local fmt = get_config().format
+      local text = format_status(xy, fmt)
       if not text then
         return nil
+      end
+      if fmt == 'porcelain' then
+        local x, y = xy:sub(1, 1), xy:sub(2, 2)
+        local xhl = x ~= ' ' and (STAT_HL[x] or 'Normal') or 'Normal'
+        local yhl = y ~= ' ' and (STAT_HL[y] or 'Normal') or 'Normal'
+        return { text, { { xhl, 0, 1 }, { yhl, 1, 2 } } }
       end
       local c = status_char(xy)
       return { text, STAT_HL[c] or 'Normal' }
@@ -312,6 +421,9 @@ M._init = function()
       if pending[dir] then
         return
       end
+      if cache_time[dir] and (vim.uv.now() - cache_time[dir]) < 2000 then
+        return
+      end
       M._cache[dir] = nil
       populate_cache(dir)
     end,
@@ -334,15 +446,19 @@ M.get_status = function(dir, name)
   if c == ' ' then
     return nil
   end
+  local x, y = xy:sub(1, 1), xy:sub(2, 2)
   return {
     status = xy,
     char = c,
     hl = STAT_HL[c] or 'Normal',
+    index = x ~= ' ' and x or nil,
+    worktree = y ~= ' ' and y or nil,
   }
 end
 
 M.invalidate = function()
   M._cache = {}
+  cache_time = {}
   pending = {}
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
     if vim.bo[bufnr].filetype == 'canola' then
@@ -353,5 +469,7 @@ M.invalidate = function()
     end
   end
 end
+
+M._stop_watchers = stop_watchers
 
 return M

--- a/spec/canola_git_spec.lua
+++ b/spec/canola_git_spec.lua
@@ -181,4 +181,89 @@ describe('canola-git', function()
       assert.is_true(hidden_fn('node_modules', 1, {}))
     end)
   end)
+
+  describe('get_status()', function()
+    before_each(function()
+      inject_mocks(make_canola_mock('/repo'), make_git_mock('/repo'), make_view_mock())
+      canola_git = require('canola-git')
+      canola_git._init()
+    end)
+
+    it('returns nil for uncached directory', function()
+      assert.is_nil(canola_git.get_status('/repo', 'file.lua'))
+    end)
+
+    it('returns nil for unknown file', function()
+      canola_git._cache = { ['/repo'] = { status = {}, tracked = {}, ignored = {} } }
+      assert.is_nil(canola_git.get_status('/repo', 'file.lua'))
+    end)
+
+    it('returns index field for staged change', function()
+      canola_git._cache =
+        { ['/repo'] = { status = { ['file.lua'] = 'M ' }, tracked = {}, ignored = {} } }
+      local result = canola_git.get_status('/repo', 'file.lua')
+      assert.equals('M', result.index)
+      assert.is_nil(result.worktree)
+    end)
+
+    it('returns worktree field for unstaged change', function()
+      canola_git._cache =
+        { ['/repo'] = { status = { ['file.lua'] = ' M' }, tracked = {}, ignored = {} } }
+      local result = canola_git.get_status('/repo', 'file.lua')
+      assert.is_nil(result.index)
+      assert.equals('M', result.worktree)
+    end)
+
+    it('returns both index and worktree for staged+unstaged', function()
+      canola_git._cache =
+        { ['/repo'] = { status = { ['file.lua'] = 'AM' }, tracked = {}, ignored = {} } }
+      local result = canola_git.get_status('/repo', 'file.lua')
+      assert.equals('A', result.index)
+      assert.equals('M', result.worktree)
+      assert.equals('AM', result.status)
+      assert.equals('A', result.char)
+    end)
+  end)
+
+  describe('git_status column render', function()
+    local render_fn
+
+    before_each(function()
+      local columns_mock = {
+        register = function(_name, def)
+          render_fn = def.render
+        end,
+      }
+      package.loaded['canola'] = make_canola_mock('/repo')
+      package.loaded['canola.git'] = make_git_mock('/repo')
+      package.loaded['canola.view'] = make_view_mock()
+      package.loaded['canola.columns'] = columns_mock
+      package.loaded['canola.constants'] = { FIELD_NAME = 2 }
+      canola_git = require('canola-git')
+      canola_git._init()
+    end)
+
+    it('returns range-based highlights for porcelain format', function()
+      vim.g.canola_git = { format = 'porcelain' }
+      canola_git._cache =
+        { ['/repo'] = { status = { ['file.lua'] = 'AM' }, tracked = {}, ignored = {} } }
+      local result = render_fn({ nil, 'file.lua' }, {}, 0)
+      assert.equals('AM', result[1])
+      assert.same({ { 'DiagnosticOk', 0, 1 }, { 'DiagnosticWarn', 1, 2 } }, result[2])
+    end)
+
+    it('returns single highlight for compact format', function()
+      canola_git._cache =
+        { ['/repo'] = { status = { ['file.lua'] = ' M' }, tracked = {}, ignored = {} } }
+      local result = render_fn({ nil, 'file.lua' }, {}, 0)
+      assert.equals('M', result[1])
+      assert.equals('DiagnosticWarn', result[2])
+    end)
+
+    it('returns nil for file without status', function()
+      canola_git._cache = { ['/repo'] = { status = {}, tracked = {}, ignored = {} } }
+      local result = render_fn({ nil, 'clean.lua' }, {}, 0)
+      assert.is_nil(result)
+    end)
+  end)
 end)


### PR DESCRIPTION
## Problem

`git status --porcelain` outputs paths relative to the repo root, but
`populate_cache` fed them through `first_component` as-is. At the repo root
this worked by coincidence; in any subdirectory the prefix mismatch meant
`cache.status` keys never matched entry names, so signs were silently absent.

## Solution

Compute the relative prefix between the browsed directory and the repo root,
strip it from each porcelain path before `first_component`. Also adds three
complementary improvements:

- **`.git` directory watcher** via `vim.uv.new_fs_event` — watches for
  `index`/`HEAD` changes with 300ms debounce, only invalidates when a canola
  buffer is visible. Handles worktree `.git` files. Provides real-time
  updates for the terminal-split workflow where neither `FocusGained` nor
  `BufEnter` fires.
- **`BufEnter` TTL** — skips re-query if cache is <2s old, eliminating
  redundant subprocess spawns on rapid buffer switching.
- **Porcelain range-based highlights** — `porcelain` format now renders
  index (X) and worktree (Y) characters with distinct highlight groups via
  `HlRangeTuple`, e.g. staged-add + unstaged-modify shows `A` in
  `DiagnosticOk` and `M` in `DiagnosticWarn`.
- **`get_status()` enrichment** — adds `index` and `worktree` convenience
  fields so consumers don't need to parse the raw porcelain XY pair.