### PR TITLE
fix: update bug report template for lazy.nvim path

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -60,7 +60,7 @@ body:
       value: |
         vim.env.LAZY_STDPATH = '.repro'
         load(vim.fn.system('curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua'))()
-        require('lazy.nvim').setup({
+        require('lazy').setup({
           spec = {
             {
               'barrettruth/canola.nvim',


### PR DESCRIPTION
`require("lazy.nvim")` doesn't work. Same thing you already fixed on the canola repo.