### PR TITLE
fix(trash): wire up delete.trash config to intercept file deletions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ enable it in canola:
 
 ```lua
 vim.g.canola = {
-  delete_to_trash = true,
+  delete = { trash = true },
 }
 ```
 

--- a/doc/canola-collection.txt
+++ b/doc/canola-collection.txt
@@ -101,7 +101,7 @@ canola-trash                                                    *canola-trash*
   macOS, and Windows.
   Scheme: `canola-trash://path`
 
-  Enable by setting `delete_to_trash = true` in `vim.g.canola`.
+  Enable by setting `delete = { trash = true }` in `vim.g.canola`.
   No adapter-specific configuration.
 
 canola-git                                                        *canola-git*

--- a/plugin/canola-collection.lua
+++ b/plugin/canola-collection.lua
@@ -13,6 +13,35 @@ if vim.fn.has('nvim-0.12') == 0 then
   canola.register_adapter('canola-sss://', 's3')
 end
 
+local config = require('canola.config')
+local files = require('canola.adapters.files')
+local fs = require('canola.fs')
+local util = require('canola.util')
+
+local orig_perform = files.perform_action
+files.perform_action = function(action, cb)
+  if action.type == 'delete' and config.delete.trash then
+    local _, path = util.parse_url(action.url)
+    assert(path)
+    path = fs.posix_to_os_path(path)
+    require('canola.adapters.trash').delete_to_trash(path, cb)
+  else
+    orig_perform(action, cb)
+  end
+end
+
+local orig_render = files.render_action
+files.render_action = function(action)
+  if action.type == 'delete' and config.delete.trash then
+    local _, path = util.parse_url(action.url)
+    assert(path)
+    local short_path = files.to_short_os_path(path, action.entry_type)
+    return string.format(' TRASH %s', short_path)
+  else
+    return orig_render(action)
+  end
+end
+
 require('canola-git')._init()
 
 vim.api.nvim_create_autocmd('BufNew', {


### PR DESCRIPTION
## Summary

- Wrap `files.perform_action` to redirect deletes to trash when `config.delete.trash` is true
- Wrap `files.render_action` to show "TRASH" instead of "DELETE" in confirmation
- Update README and vimdoc: `delete_to_trash` → `delete = { trash = true }`

Requires barrettruth/canola.nvim#291 for the `delete.trash` config field.

cc @llakala — the config key changed from the old `delete_to_trash` to
`delete = { trash = true }`, nesting it with the other delete options
(`wipe`, `recursive`).

#### Test plan

- [x] Set `delete = { trash = true }` in `vim.g.canola`
- [x] Delete a file in canola, confirm dialog shows "TRASH" not "DELETE"
- [x] File appears in freedesktop trash (`~/.local/share/Trash/`)
- [x] Without the flag, deletions are permanent as before

Closes #40