### PR TITLE
ci: use self-hosted runners

### DIFF
--- a/.github/workflows/luarocks.yaml
+++ b/.github/workflows/luarocks.yaml
@@ -11,7 +11,7 @@ jobs:
 
   publish:
     needs: quality
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   changes:
     runs-on: [self-hosted, linux, x64, netcup, general]
+    permissions:
+      pull-requests: read
     outputs:
       lua: ${{ steps.changes.outputs.lua }}
       markdown: ${{ steps.changes.outputs.markdown }}

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     outputs:
       lua: ${{ steps.changes.outputs.lua }}
       markdown: ${{ steps.changes.outputs.markdown }}
@@ -35,7 +35,7 @@ jobs:
 
   lua-format:
     name: Lua Format Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     needs: changes
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
@@ -45,7 +45,7 @@ jobs:
 
   lua-lint:
     name: Lua Lint Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     needs: changes
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
@@ -55,7 +55,7 @@ jobs:
 
   lua-typecheck:
     name: Lua Type Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     needs: changes
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
@@ -74,7 +74,7 @@ jobs:
 
   vimdoc-check:
     name: Vimdoc Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     needs: changes
     if: ${{ needs.changes.outputs.vimdoc == 'true' }}
     steps:
@@ -86,7 +86,7 @@ jobs:
 
   markdown-format:
     name: Markdown Format Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     needs: changes
     if: ${{ needs.changes.outputs.markdown == 'true' }}
     steps:

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -18,9 +18,12 @@ jobs:
       vimdoc: ${{ steps.changes.outputs.vimdoc }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: repo
       - uses: dorny/paths-filter@v3
         id: changes
         with:
+          working-directory: repo
           filters: |
             lua:
               - 'lua/**'
@@ -42,8 +45,11 @@ jobs:
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: repo
       - uses: cachix/install-nix-action@v31
       - run: nix develop --command stylua --check .
+        working-directory: repo
 
   lua-lint:
     name: Lua Lint Check
@@ -52,8 +58,11 @@ jobs:
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: repo
       - uses: cachix/install-nix-action@v31
       - run: nix develop --command selene --display-style quiet .
+        working-directory: repo
 
   lua-typecheck:
     name: Lua Type Check
@@ -62,17 +71,21 @@ jobs:
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: repo
       - uses: actions/checkout@v4
+        with:
+          path: repo
       - uses: actions/checkout@v4
         with:
           repository: barrettruth/canola.nvim
           ref: canola
-          path: _canola
+          path: repo/_canola
       - uses: stevearc/nvim-typecheck-action@v2
         with:
-          path: lua
+          path: repo/lua
           luals-version: 3.16.4
-          libraries: ${{ github.workspace }}/_canola/lua
+          libraries: ${{ github.workspace }}/repo/_canola/lua
 
   vimdoc-check:
     name: Vimdoc Check
@@ -81,10 +94,13 @@ jobs:
     if: ${{ needs.changes.outputs.vimdoc == 'true' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: repo
       - uses: cachix/install-nix-action@v31
       - run:
           nix develop --command vimdoc-language-server check doc/
           --no-runtime-tags
+        working-directory: repo
 
   markdown-format:
     name: Markdown Format Check
@@ -93,5 +109,8 @@ jobs:
     if: ${{ needs.changes.outputs.markdown == 'true' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: repo
       - uses: cachix/install-nix-action@v31
       - run: nix develop --command prettier --check .
+        working-directory: repo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,10 @@ jobs:
       image: ubuntu:24.04
       volumes:
         - /nix/store:/nix/store:ro
+        - /etc/ssl:/etc/ssl:ro
+        - /etc/static:/etc/static:ro
+      env:
+        SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     runs-on: [self-hosted, linux, x64, netcup, general]
+    container: ubuntu:24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,10 @@ on:
 jobs:
   test:
     runs-on: [self-hosted, linux, x64, netcup, general]
-    container: ubuntu:24.04
+    container:
+      image: ubuntu:24.04
+      volumes:
+        - /nix/store:/nix/store:ro
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,20 +17,20 @@ jobs:
         - /etc/static:/etc/static:ro
       env:
         SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+        TMPDIR: /github/home/tmp
     strategy:
       fail-fast: false
       matrix:
         nvim: [stable, nightly]
     name: Test (Neovim ${{ matrix.nvim }})
     steps:
+      - run: mkdir -p $TMPDIR && apt-get update && apt-get install -y sudo git
       - uses: actions/checkout@v4
-
       - uses: actions/checkout@v4
         with:
           repository: barrettruth/canola.nvim
           ref: canola
           path: _canola
-
       - uses: nvim-neorocks/nvim-busted-action@v1
         with:
           nvim_version: ${{ matrix.nvim }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,11 +16,13 @@ jobs:
     name: Test (Neovim ${{ matrix.nvim }})
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: repo
       - uses: actions/checkout@v4
         with:
           repository: barrettruth/canola.nvim
           ref: canola
-          path: _canola
+          path: repo/_canola
       - uses: rhysd/action-setup-vim@v1
         id: setup-vim
         with:
@@ -29,3 +31,4 @@ jobs:
       - run: |
           export PATH="$(dirname '${{ steps.setup-vim.outputs.executable }}'):$PATH"
           nix shell nixpkgs#luajitPackages.busted nixpkgs#luajitPackages.nlua --command busted
+        working-directory: repo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,7 @@ jobs:
       image: ubuntu:24.04
       volumes:
         - /nix/store:/nix/store:ro
-        - /etc/ssl:/etc/ssl:ro
-        - /etc/static:/etc/static:ro
       env:
-        SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
         TMPDIR: /github/home/tmp
     strategy:
       fail-fast: false
@@ -24,7 +21,12 @@ jobs:
         nvim: [stable, nightly]
     name: Test (Neovim ${{ matrix.nvim }})
     steps:
-      - run: mkdir -p $TMPDIR && apt-get update && apt-get install -y sudo git
+      - run: |
+          mkdir -p $TMPDIR
+          cert=$(ls /nix/store/*-nss-cacert-*/etc/ssl/certs/ca-bundle.crt 2>/dev/null | head -1)
+          echo "SSL_CERT_FILE=$cert" >> $GITHUB_ENV
+          echo "NODE_EXTRA_CA_CERTS=$cert" >> $GITHUB_ENV
+          apt-get update && apt-get install -y sudo git
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,4 +28,4 @@ jobs:
           version: ${{ matrix.nvim }}
       - run: |
           export PATH="$(dirname '${{ steps.setup-vim.outputs.executable }}'):$PATH"
-          nix develop --command busted
+          nix shell nixpkgs#luajitPackages.busted nixpkgs#luajitPackages.nlua --command busted

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,30 +9,23 @@ on:
 jobs:
   test:
     runs-on: [self-hosted, linux, x64, netcup, general]
-    container:
-      image: ubuntu:24.04
-      volumes:
-        - /nix/store:/nix/store:ro
-      env:
-        TMPDIR: /github/home/tmp
     strategy:
       fail-fast: false
       matrix:
         nvim: [stable, nightly]
     name: Test (Neovim ${{ matrix.nvim }})
     steps:
-      - run: |
-          mkdir -p $TMPDIR
-          cert=$(ls /nix/store/*-nss-cacert-*/etc/ssl/certs/ca-bundle.crt 2>/dev/null | head -1)
-          echo "SSL_CERT_FILE=$cert" >> $GITHUB_ENV
-          echo "NODE_EXTRA_CA_CERTS=$cert" >> $GITHUB_ENV
-          apt-get update && apt-get install -y sudo git
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4
         with:
           repository: barrettruth/canola.nvim
           ref: canola
           path: _canola
-      - uses: nvim-neorocks/nvim-busted-action@v1
+      - uses: rhysd/action-setup-vim@v1
+        id: setup-vim
         with:
-          nvim_version: ${{ matrix.nvim }}
+          neovim: true
+          version: ${{ matrix.nvim }}
+      - run: |
+          export PATH="$(dirname '${{ steps.setup-vim.outputs.executable }}'):$PATH"
+          nix develop --command busted


### PR DESCRIPTION
## Summary
- Replace `runs-on: ubuntu-latest` with `runs-on: [self-hosted, linux, x64, netcup, general]` in all workflow files

#### Test plan
- [ ] All CI jobs run successfully on the self-hosted runner