### PR TITLE
fix: opt in to collection features by config presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,14 @@ Install with your package manager of choice or via
 luarocks install canola-collection
 ```
 
-Adapters register themselves automatically on load. No `setup()` call needed.
+Components are opt-in. Define a component's `vim.g.canola_*` table before
+canola-collection loads to register it. Empty tables enable defaults. No
+`setup()` call needed.
 
 ## Configuration
 
-Each component has its own `vim.g` table. All are optional — defaults work out
-of the box.
+Each component has its own `vim.g` table. Define only the ones you want; empty
+tables enable defaults.
 
 ### canola-git
 
@@ -35,9 +37,10 @@ Git-aware hidden file filtering and a `git_status` column. Tracked dotfiles
 (`.gitignore`, `.github/`) stay visible. Gitignored files disappear. Directories
 show the most severe status among their children.
 
+Define `vim.g.canola_git` to enable canola-git. An empty table enables defaults.
+
 ```lua
 vim.g.canola_git = {
-  enabled = true,
   show = { untracked = true, ignored = false },
   format = 'compact', -- 'compact' | 'symbol' | 'porcelain'
 }
@@ -62,6 +65,9 @@ require('canola-git').invalidate()
 
 Browse remote filesystems via SSH. Uses SCP for file transfers.
 
+Define `vim.g.canola_ssh` to enable SSH support. An empty table enables
+defaults.
+
 ```lua
 vim.g.canola_ssh = {
   extra_args = {},
@@ -79,6 +85,8 @@ Open with `:edit canola-ssh://user@host/path/`.
 
 Browse AWS S3 buckets via the `aws` CLI.
 
+Define `vim.g.canola_s3` to enable S3 support. An empty table enables defaults.
+
 ```lua
 vim.g.canola_s3 = {
   extra_args = {},
@@ -95,6 +103,9 @@ Open with `:edit canola-s3://bucket/prefix/`.
 
 Browse FTP/FTPS servers via `curl`.
 
+Define `vim.g.canola_ftp` to enable FTP/FTPS support. An empty table enables
+defaults.
+
 ```lua
 vim.g.canola_ftp = {
   extra_args = {},
@@ -109,13 +120,11 @@ Open with `:edit canola-ftp://host/path/` or `canola-ftps://host/path/`.
 
 ### canola-trash
 
-OS-specific recycle bin (freedesktop, macOS, Windows). No separate config —
-enable it in canola:
+OS-specific recycle bin (freedesktop, macOS, Windows). Define
+`vim.g.canola_trash` to enable it. An empty table enables defaults:
 
 ```lua
-vim.g.canola = {
-  delete = { trash = true },
-}
+vim.g.canola_trash = {}
 ```
 
 ### canola-resession

--- a/doc/canola-collection.txt
+++ b/doc/canola-collection.txt
@@ -22,8 +22,9 @@ CONTENTS                                          *canola-collection-contents*
 OVERVIEW                                                   *canola-collection*
 
 canola-collection provides optional adapters and extensions for canola.nvim.
-All adapters are lazy-loaded and only activate when their URL scheme is first
-accessed. Adapter-specific configuration uses per-adapter `vim.g` tables.
+Components are opt-in. Define a component's `vim.g.canola_*` table before
+canola-collection loads to register it. Empty tables enable defaults. Adapter
+implementations are lazy-loaded when their URL scheme is first accessed.
 
 ==============================================================================
 ADAPTERS                                          *canola-collection-adapters*
@@ -31,6 +32,8 @@ ADAPTERS                                          *canola-collection-adapters*
 canola-ssh                                                        *canola-ssh*
   Browse remote filesystems via SSH. Uses SCP for file transfers.
   Scheme: `canola-ssh://[user@]host[:port]/path`
+  Define `vim.g.canola_ssh` to enable SSH support. An empty table enables
+  defaults.
 
   Configuration:                                           *vim.g.canola_ssh*
   >lua
@@ -56,6 +59,8 @@ canola-ssh                                                        *canola-ssh*
 canola-s3                                                          *canola-s3*
   Browse AWS S3 buckets via the `aws` CLI.
   Scheme: `canola-s3://bucket/prefix`
+  Define `vim.g.canola_s3` to enable S3 support. An empty table enables
+  defaults.
 
   Configuration:                                            *vim.g.canola_s3*
   >lua
@@ -77,6 +82,8 @@ canola-s3                                                          *canola-s3*
 canola-ftp                                                        *canola-ftp*
   Browse FTP/FTPS servers via `curl`.
   Scheme: `canola-ftp://host/path` or `canola-ftps://host/path`
+  Define `vim.g.canola_ftp` to enable FTP/FTPS support. An empty table
+  enables defaults.
 
   Configuration:                                           *vim.g.canola_ftp*
   >lua
@@ -101,25 +108,22 @@ canola-trash                                                    *canola-trash*
   macOS, and Windows.
   Scheme: `canola-trash://path`
 
-  Enable by setting `delete = { trash = true }` in `vim.g.canola`.
-  No adapter-specific configuration.
+  Define `vim.g.canola_trash` to enable trash support. An empty table enables
+  defaults.
 
 canola-git                                                        *canola-git*
   Git-aware hidden file filtering for local directories. Replaces the default
   dotfile filter with one that respects the git index: tracked dotfiles are
-  shown, untracked dotfiles and ignored files are hidden. Activates
-  automatically when canola-collection is loaded.
+  shown, untracked dotfiles and ignored files are hidden. Define
+  `vim.g.canola_git` to enable canola-git. An empty table enables defaults.
 
   Configuration:                                           *vim.g.canola_git*
   >lua
     vim.g.canola_git = {
-      enabled = true,
       show    = { untracked = true, ignored = false },
       format  = 'compact',
     }
 <
-  enabled       When `false`, disables all canola-git behaviour.
-
   show.untracked  When `false`, untracked non-dotfiles (new files not yet
                 staged or committed) are hidden alongside ignored files.
                 Default: `true`.

--- a/lua/canola-git/init.lua
+++ b/lua/canola-git/init.lua
@@ -1,5 +1,4 @@
 ---@class (exact) canola.git.Config
----@field enabled boolean
 ---@field show {untracked: boolean, ignored: boolean}
 ---@field format 'compact'|'porcelain'|'symbol'
 
@@ -55,7 +54,6 @@ local STATUS_PRIORITY = {
 ---@return canola.git.Config
 local function get_config()
   return vim.tbl_deep_extend('keep', vim.g.canola_git or {}, {
-    enabled = true,
     show = { untracked = true, ignored = false },
     format = 'compact',
   })
@@ -370,11 +368,6 @@ M._init = function()
       return { text, STAT_HL[c] or 'Normal' }
     end,
   })
-
-  local cfg = get_config()
-  if not cfg.enabled then
-    return
-  end
 
   require('canola').set_is_hidden_file(function(name, bufnr, _entry)
     return is_hidden(name, bufnr)

--- a/plugin/canola-collection.lua
+++ b/plugin/canola-collection.lua
@@ -3,51 +3,69 @@ if not ok then
   return
 end
 
-canola.register_adapter('canola-ssh://', 'ssh')
-canola.register_adapter('canola-s3://', 's3')
-canola.register_adapter('canola-trash://', 'trash')
-canola.register_adapter('canola-ftp://', 'ftp')
-canola.register_adapter('canola-ftps://', 'ftps')
-
-if vim.fn.has('nvim-0.12') == 0 then
-  canola.register_adapter('canola-sss://', 's3')
+---@param cfg unknown
+---@return boolean
+local function configured(cfg)
+  return type(cfg) == 'table'
 end
 
-local config = require('canola.config')
-local files = require('canola.adapters.files')
-local fs = require('canola.fs')
-local util = require('canola.util')
+if configured(vim.g.canola_ssh) then
+  canola.register_adapter('canola-ssh://', 'ssh')
 
-local orig_perform = files.perform_action
-files.perform_action = function(action, cb)
-  if action.type == 'delete' and config.delete.trash then
-    local _, path = util.parse_url(action.url)
-    assert(path)
-    path = fs.posix_to_os_path(path)
-    require('canola.adapters.trash').delete_to_trash(path, cb)
-  else
-    orig_perform(action, cb)
+  vim.api.nvim_create_autocmd('BufNew', {
+    pattern = 'scp://*',
+    once = true,
+    callback = function()
+      vim.notify('Use canola-ssh:// instead of scp://', vim.log.levels.WARN)
+    end,
+  })
+end
+
+if configured(vim.g.canola_s3) then
+  canola.register_adapter('canola-s3://', 's3')
+
+  if vim.fn.has('nvim-0.12') == 0 then
+    canola.register_adapter('canola-sss://', 's3')
   end
 end
 
-local orig_render = files.render_action
-files.render_action = function(action)
-  if action.type == 'delete' and config.delete.trash then
-    local _, path = util.parse_url(action.url)
-    assert(path)
-    local short_path = files.to_short_os_path(path, action.entry_type)
-    return string.format(' TRASH %s', short_path)
-  else
-    return orig_render(action)
+if configured(vim.g.canola_ftp) then
+  canola.register_adapter('canola-ftp://', 'ftp')
+  canola.register_adapter('canola-ftps://', 'ftps')
+end
+
+if configured(vim.g.canola_trash) then
+  canola.register_adapter('canola-trash://', 'trash')
+
+  local files = require('canola.adapters.files')
+  local fs = require('canola.fs')
+  local util = require('canola.util')
+
+  local orig_perform = files.perform_action
+  files.perform_action = function(action, cb)
+    if action.type == 'delete' then
+      local _, path = util.parse_url(action.url)
+      assert(path)
+      path = fs.posix_to_os_path(path)
+      require('canola.adapters.trash').delete_to_trash(path, cb)
+    else
+      orig_perform(action, cb)
+    end
+  end
+
+  local orig_render = files.render_action
+  files.render_action = function(action)
+    if action.type == 'delete' then
+      local _, path = util.parse_url(action.url)
+      assert(path)
+      local short_path = files.to_short_os_path(path, action.entry_type)
+      return string.format(' TRASH %s', short_path)
+    else
+      return orig_render(action)
+    end
   end
 end
 
-require('canola-git')._init()
-
-vim.api.nvim_create_autocmd('BufNew', {
-  pattern = 'scp://*',
-  once = true,
-  callback = function()
-    vim.notify('Use canola-ssh:// instead of scp://', vim.log.levels.WARN)
-  end,
-})
+if configured(vim.g.canola_git) then
+  require('canola-git')._init()
+end

--- a/spec/canola_git_spec.lua
+++ b/spec/canola_git_spec.lua
@@ -74,19 +74,6 @@ describe('canola-git', function()
       canola_git._init()
       assert.is_function(registered_fn)
     end)
-
-    it('skips is_hidden_file when enabled = false', function()
-      vim.g.canola_git = { enabled = false }
-      local call_count = 0
-      local canola_mock = make_canola_mock(nil)
-      canola_mock.set_is_hidden_file = function(_fn)
-        call_count = call_count + 1
-      end
-      inject_mocks(canola_mock, make_git_mock(nil), make_view_mock())
-      canola_git = require('canola-git')
-      canola_git._init()
-      assert.equals(0, call_count)
-    end)
   end)
 
   describe('is_hidden_file fallback (no cached data)', function()

--- a/spec/plugin_spec.lua
+++ b/spec/plugin_spec.lua
@@ -1,0 +1,164 @@
+local plugin_path = vim.fn.fnamemodify(debug.getinfo(1, 'S').source:sub(2), ':h:h')
+  .. '/plugin/canola-collection.lua'
+
+local function parse_url(url)
+  return url:match('^(.-://)(.*)$')
+end
+
+local function clear_state()
+  package.loaded['canola'] = nil
+  package.loaded['canola-git'] = nil
+  package.loaded['canola.adapters.files'] = nil
+  package.loaded['canola.adapters.trash'] = nil
+  package.loaded['canola.fs'] = nil
+  package.loaded['canola.util'] = nil
+  vim.g.canola = nil
+  vim.g.canola_git = nil
+  vim.g.canola_ssh = nil
+  vim.g.canola_s3 = nil
+  vim.g.canola_ftp = nil
+  vim.g.canola_trash = nil
+end
+
+local function has_registration(calls, scheme, name)
+  for _, call in ipairs(calls) do
+    if call.scheme == scheme and call.name == name then
+      return true
+    end
+  end
+  return false
+end
+
+describe('plugin/canola-collection.lua', function()
+  local register_calls
+  local autocmds
+  local git_init_calls
+  local trash_deletes
+  local files
+  local original_create_autocmd
+
+  before_each(function()
+    clear_state()
+    register_calls = {}
+    autocmds = {}
+    git_init_calls = 0
+    trash_deletes = {}
+    files = {
+      perform_action = function(_action, cb)
+        cb('orig')
+      end,
+      render_action = function(_action)
+        return 'orig'
+      end,
+      to_short_os_path = function(path, _entry_type)
+        return path
+      end,
+    }
+    package.loaded['canola'] = {
+      register_adapter = function(scheme, name)
+        table.insert(register_calls, { scheme = scheme, name = name })
+      end,
+    }
+    package.loaded['canola-git'] = {
+      _init = function()
+        git_init_calls = git_init_calls + 1
+      end,
+    }
+    package.loaded['canola.adapters.files'] = files
+    package.loaded['canola.adapters.trash'] = {
+      delete_to_trash = function(path, cb)
+        table.insert(trash_deletes, path)
+        cb()
+      end,
+    }
+    package.loaded['canola.fs'] = {
+      posix_to_os_path = function(path)
+        return path
+      end,
+    }
+    package.loaded['canola.util'] = {
+      parse_url = parse_url,
+    }
+    original_create_autocmd = vim.api.nvim_create_autocmd
+    vim.api.nvim_create_autocmd = function(event, opts)
+      table.insert(autocmds, { event = event, opts = opts })
+      return #autocmds
+    end
+  end)
+
+  after_each(function()
+    vim.api.nvim_create_autocmd = original_create_autocmd
+    clear_state()
+  end)
+
+  it('does not activate any feature by default', function()
+    local orig_perform = files.perform_action
+    local orig_render = files.render_action
+    dofile(plugin_path)
+    assert.are.same({}, register_calls)
+    assert.are.same({}, autocmds)
+    assert.equals(0, git_init_calls)
+    assert.equals(orig_perform, files.perform_action)
+    assert.equals(orig_render, files.render_action)
+  end)
+
+  it('treats an empty ssh table as enabled', function()
+    vim.g.canola_ssh = {}
+    dofile(plugin_path)
+    assert.is_true(has_registration(register_calls, 'canola-ssh://', 'ssh'))
+    assert.equals('BufNew', autocmds[1].event)
+    assert.equals('scp://*', autocmds[1].opts.pattern)
+  end)
+
+  it('treats an empty s3 table as enabled', function()
+    vim.g.canola_s3 = {}
+    dofile(plugin_path)
+    assert.is_true(has_registration(register_calls, 'canola-s3://', 's3'))
+  end)
+
+  it('treats an empty ftp table as enabled', function()
+    vim.g.canola_ftp = {}
+    dofile(plugin_path)
+    assert.is_true(has_registration(register_calls, 'canola-ftp://', 'ftp'))
+    assert.is_true(has_registration(register_calls, 'canola-ftps://', 'ftps'))
+  end)
+
+  it('treats an empty trash table as enabled', function()
+    vim.g.canola_trash = {}
+    local orig_perform = files.perform_action
+    local orig_render = files.render_action
+    dofile(plugin_path)
+    assert.is_true(has_registration(register_calls, 'canola-trash://', 'trash'))
+    assert.not_equals(orig_perform, files.perform_action)
+    assert.not_equals(orig_render, files.render_action)
+    local err
+    files.perform_action(
+      { type = 'delete', url = 'oil:///tmp/file', entry_type = 'file' },
+      function(e)
+        err = e
+      end
+    )
+    assert.is_nil(err)
+    assert.are.same({ '/tmp/file' }, trash_deletes)
+    assert.equals(
+      ' TRASH /tmp/file',
+      files.render_action({ type = 'delete', url = 'oil:///tmp/file', entry_type = 'file' })
+    )
+  end)
+
+  it('does not enable trash from vim.g.canola.delete.trash', function()
+    vim.g.canola = { delete = { trash = true } }
+    local orig_perform = files.perform_action
+    local orig_render = files.render_action
+    dofile(plugin_path)
+    assert.is_false(has_registration(register_calls, 'canola-trash://', 'trash'))
+    assert.equals(orig_perform, files.perform_action)
+    assert.equals(orig_render, files.render_action)
+  end)
+
+  it('treats an empty git table as enabled', function()
+    vim.g.canola_git = {}
+    dofile(plugin_path)
+    assert.equals(1, git_init_calls)
+  end)
+end)


### PR DESCRIPTION
## Problem

canola-collection registered every optional feature at startup, so users paid setup cost for adapters and git integration they never configured. Trash still used `vim.g.canola.delete.trash`, and `canola-git` kept its own `enabled` toggle, which left the collection with an inconsistent config model.

## Solution

Treat every collection feature as opt-in by config presence: only register SSH, S3, FTP, trash, and git when their `vim.g.canola_*` table is defined, with `{}` enabling defaults. Move trash opt-in to `vim.g.canola_trash`, remove the remaining extension-side `enabled` handling from `canola-git`, and update docs/specs to cover the presence-based model. Closes #46.