### PR TITLE
ci: drop --no-runtime-tags from vimdoc check

### DIFF
--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ format:
 lint:
     git ls-files '*.lua' | xargs selene --display-style quiet
     sh -ceu 'canola_lib=$(test -d _canola && echo _canola || echo "$HOME/dev/canola.nvim")/lua; luarc_tmp=$(mktemp --suffix=.json); trap "rm -f \"$luarc_tmp\"" EXIT; python3 -c "import json, sys; cfg = json.load(open(\".luarc.json\")); cfg.setdefault(\"workspace\", {}).setdefault(\"library\", []).append(sys.argv[1]); print(json.dumps(cfg))" "$canola_lib" > "$luarc_tmp"; lua-language-server --check lua --checklevel=Error --configpath="$luarc_tmp"'
-    vimdoc-language-server check doc/ --no-runtime-tags
+    vimdoc-language-server check doc/
 
 test:
     busted


### PR DESCRIPTION
## Problem

The `lint` recipe ran `vimdoc-language-server check doc/ --no-runtime-tags`, carried over from the old `scripts/ci.sh` when the justfile was introduced in #51. The `ci` shell already bundles Neovim, so `$VIMRUNTIME/doc/tags` is available; the flag was suppressing real `|taglink|` validation against the bundled runtime for no benefit.

## Solution

Drop `--no-runtime-tags` from the `lint` recipe. `just ci` continues to pass locally (`0 diagnostics`, `83 successes / 0 failures`).
