### PR TITLE
feat(canola-git): emit cache update event and keep raw path statuses

### DIFF
--- a/doc/canola-collection.txt
+++ b/doc/canola-collection.txt
@@ -197,18 +197,12 @@ canola-git                                                        *canola-git*
                        `focus_gained`, `shell_cmd_post`, `buf_enter`,
                        or `watch`.
 
-  Example — print git update reason: >lua
+  For example, to print the update reason and inspect raw cached path
+  statuses: >lua
     vim.api.nvim_create_autocmd('User', {
       pattern = 'CanolaGitUpdate',
       callback = function(args)
         print(args.data.reason)
-      end,
-    })
-<
-  Example — inspect raw cached path statuses: >lua
-    vim.api.nvim_create_autocmd('User', {
-      pattern = 'CanolaGitUpdate',
-      callback = function(args)
         local cache = require('canola-git')._cache[args.data.dir]
         if not cache or cache == false then
           return

--- a/doc/canola-collection.txt
+++ b/doc/canola-collection.txt
@@ -186,6 +186,40 @@ canola-git                                                        *canola-git*
     })
 <
 
+  Update event ~                                              *CanolaGitUpdate*
+  `CanolaGitUpdate` fires after canola-git refreshes the cached git
+  snapshot for a local directory and before canola buffers rerender.
+
+  `args.data` fields:
+    `dir`    `string`  Absolute directory path whose cache was refreshed.
+    `root`   `string`  Git repository root containing `dir`.
+    `reason` `string`  One of `initial`, `manual`, `mutation_complete`,
+                       `focus_gained`, `shell_cmd_post`, `buf_enter`,
+                       or `watch`.
+
+  Example — print git update reason: >lua
+    vim.api.nvim_create_autocmd('User', {
+      pattern = 'CanolaGitUpdate',
+      callback = function(args)
+        print(args.data.reason)
+      end,
+    })
+<
+  Example — inspect raw cached path statuses: >lua
+    vim.api.nvim_create_autocmd('User', {
+      pattern = 'CanolaGitUpdate',
+      callback = function(args)
+        local cache = require('canola-git')._cache[args.data.dir]
+        if not cache or cache == false then
+          return
+        end
+        for path, st in pairs(cache.path_status) do
+          print(path, st.type, st.status)
+        end
+      end,
+    })
+<
+
   Status API ~
                                               *canola-git.get_status()*
   >lua

--- a/lua/canola-git/init.lua
+++ b/lua/canola-git/init.lua
@@ -2,17 +2,52 @@
 ---@field show {untracked: boolean, ignored: boolean}
 ---@field format 'compact'|'porcelain'|'symbol'
 
+---@alias canola.git.PathStatusType
+---| 'added'
+---| 'copied'
+---| 'deleted'
+---| 'modified'
+---| 'renamed'
+---| 'type_changed'
+---| 'unmerged'
+---| 'unknown'
+---| 'untracked'
+
+---@alias canola.git.UpdateReason
+---| 'buf_enter'
+---| 'focus_gained'
+---| 'initial'
+---| 'manual'
+---| 'mutation_complete'
+---| 'shell_cmd_post'
+---| 'watch'
+
+---@class (exact) canola.git.PathStatus
+---@field status string Raw two-character porcelain code.
+---@field char string Resolved single-character status.
+---@field type canola.git.PathStatusType Primary status kind for recipes.
+---@field index string? Index status character when present.
+---@field worktree string? Worktree status character when present.
+---@field source_path string? Source path relative to dir for rename/copy entries.
+
 ---@class (exact) canola.git.CacheEntry
----@field ignored table<string, boolean>
----@field tracked table<string, boolean>
----@field status table<string, string>
+---@field root string Git repository root for this cache entry.
+---@field ignored table<string, boolean> First-level ignored names in this dir.
+---@field tracked table<string, boolean> First-level tracked names in this dir.
+---@field status table<string, string> Aggregated first-level statuses for visible entries.
+---@field path_status table<string, canola.git.PathStatus> Raw statuses keyed by path relative to dir.
 
 ---@class (exact) canola.git.StatusResult
----@field status string
----@field char string
----@field hl string
----@field index string?
----@field worktree string?
+---@field status string Raw two-character porcelain code.
+---@field char string Resolved single-character status.
+---@field hl string Highlight group for the resolved status.
+---@field index string? Index status character when present.
+---@field worktree string? Worktree status character when present.
+
+---@class (exact) canola.git.UpdateEventData
+---@field dir string Absolute directory path whose cache was refreshed.
+---@field root string Git repository root containing dir.
+---@field reason canola.git.UpdateReason What triggered the refresh.
 
 local M = {}
 
@@ -46,9 +81,22 @@ local STATUS_PRIORITY = {
   ['M'] = 4,
   ['R'] = 3,
   ['C'] = 3,
+  ['T'] = 3,
   ['A'] = 2,
   ['?'] = 1,
   ['!'] = 0,
+}
+
+---@type table<string, canola.git.PathStatusType>
+local STATUS_TYPE = {
+  ['?'] = 'untracked',
+  ['A'] = 'added',
+  ['C'] = 'copied',
+  ['D'] = 'deleted',
+  ['M'] = 'modified',
+  ['R'] = 'renamed',
+  ['T'] = 'type_changed',
+  ['U'] = 'unmerged',
 }
 
 ---@return canola.git.Config
@@ -98,6 +146,53 @@ end
 local function first_component(path)
   local slash = path:find('/', 1, true)
   return slash and path:sub(1, slash - 1) or path
+end
+
+---@param path string
+---@param relprefix string
+---@return string
+local function normalize_path(path, relprefix)
+  path = path:gsub('/$', '')
+  if relprefix ~= '' and path:sub(1, #relprefix) == relprefix then
+    path = path:sub(#relprefix + 1)
+  end
+  return path
+end
+
+---@param xy string
+---@return canola.git.PathStatusType
+local function status_type(xy)
+  return STATUS_TYPE[status_char(xy)] or 'unknown'
+end
+
+---@param xy string
+---@param source_path string?
+---@return canola.git.PathStatus
+local function make_path_status(xy, source_path)
+  local x, y = xy:sub(1, 1), xy:sub(2, 2)
+  return {
+    status = xy,
+    char = status_char(xy),
+    type = status_type(xy),
+    index = x ~= ' ' and x or nil,
+    worktree = y ~= ' ' and y or nil,
+    source_path = source_path,
+  }
+end
+
+---@param dir string
+---@param root string
+---@param reason canola.git.UpdateReason
+local function emit_update(dir, root, reason)
+  vim.api.nvim_exec_autocmds('User', {
+    pattern = 'CanolaGitUpdate',
+    modeline = false,
+    data = {
+      dir = dir,
+      root = root,
+      reason = reason,
+    },
+  })
 end
 
 ---@param root string
@@ -160,7 +255,7 @@ local function start_watcher(root)
             if vim.api.nvim_win_is_valid(winid) then
               local bufnr = vim.api.nvim_win_get_buf(winid)
               if vim.bo[bufnr].filetype == 'canola' then
-                M.invalidate()
+                M.invalidate('watch')
                 return
               end
             end
@@ -186,7 +281,8 @@ local function stop_watchers()
 end
 
 ---@param dir string
-local function populate_cache(dir)
+---@param reason canola.git.UpdateReason
+local function populate_cache(dir, reason)
   if pending[dir] then
     return
   end
@@ -215,6 +311,8 @@ local function populate_cache(dir)
   local tracked
   ---@type table<string, string>
   local status
+  ---@type table<string, canola.git.PathStatus>
+  local path_status
   local remaining = 3
 
   local function on_query_done()
@@ -222,9 +320,16 @@ local function populate_cache(dir)
     if remaining > 0 then
       return
     end
-    M._cache[dir] = { ignored = ignored, tracked = tracked, status = status }
+    M._cache[dir] = {
+      root = root,
+      ignored = ignored,
+      tracked = tracked,
+      status = status,
+      path_status = path_status,
+    }
     cache_time[dir] = vim.uv.now()
     pending[dir] = nil
+    emit_update(dir, root, reason)
     require('canola.view').rerender_all_oil_buffers({ refetch = false })
   end
 
@@ -266,18 +371,24 @@ local function populate_cache(dir)
     { cwd = dir, text = true },
     vim.schedule_wrap(function(result)
       status = {}
+      path_status = {}
       if result.code == 0 then
         for _, line in ipairs(vim.split(result.stdout, '\n', { plain = true })) do
           if #line >= 4 then
             local xy = line:sub(1, 2)
             local path = line:sub(4)
+            local source_path
             local arrow = path:find(' -> ', 1, true)
             if arrow then
+              source_path = path:sub(1, arrow - 1)
               path = path:sub(arrow + 4)
             end
-            path = path:gsub('/$', '')
-            if relprefix ~= '' and path:sub(1, #relprefix) == relprefix then
-              path = path:sub(#relprefix + 1)
+            path = normalize_path(path, relprefix)
+            if source_path then
+              source_path = normalize_path(source_path, relprefix)
+            end
+            if path ~= '' then
+              path_status[path] = make_path_status(xy, source_path)
             end
             local name = first_component(path)
             if name ~= '' then
@@ -385,20 +496,26 @@ M._init = function()
       if M._cache[dir] ~= nil then
         return
       end
-      populate_cache(dir)
+      populate_cache(dir, 'initial')
     end,
   })
 
   vim.api.nvim_create_autocmd('User', {
     pattern = 'CanolaMutationComplete',
     callback = function()
-      M.invalidate()
+      M.invalidate('mutation_complete')
     end,
   })
 
-  vim.api.nvim_create_autocmd({ 'FocusGained', 'ShellCmdPost' }, {
+  vim.api.nvim_create_autocmd('FocusGained', {
     callback = function()
-      M.invalidate()
+      M.invalidate('focus_gained')
+    end,
+  })
+
+  vim.api.nvim_create_autocmd('ShellCmdPost', {
+    callback = function()
+      M.invalidate('shell_cmd_post')
     end,
   })
 
@@ -418,7 +535,7 @@ M._init = function()
         return
       end
       M._cache[dir] = nil
-      populate_cache(dir)
+      populate_cache(dir, 'buf_enter')
     end,
   })
 end
@@ -449,7 +566,9 @@ M.get_status = function(dir, name)
   }
 end
 
-M.invalidate = function()
+---@param reason? canola.git.UpdateReason
+M.invalidate = function(reason)
+  reason = reason or 'manual'
   M._cache = {}
   cache_time = {}
   pending = {}
@@ -457,7 +576,7 @@ M.invalidate = function()
     if vim.bo[bufnr].filetype == 'canola' then
       local ok, dir = pcall(require('canola').get_current_dir, bufnr)
       if ok and dir then
-        populate_cache(dir)
+        populate_cache(dir, reason)
       end
     end
   end

--- a/lua/canola-git/init.lua
+++ b/lua/canola-git/init.lua
@@ -367,7 +367,7 @@ local function populate_cache(dir, reason)
   )
 
   vim.system(
-    { 'git', 'status', '--porcelain', '--', '.' },
+    { 'git', '--no-optional-locks', 'status', '--porcelain', '--', '.' },
     { cwd = dir, text = true },
     vim.schedule_wrap(function(result)
       status = {}
@@ -522,6 +522,9 @@ M._init = function()
   vim.api.nvim_create_autocmd('BufEnter', {
     callback = function(args)
       if vim.bo[args.buf].filetype ~= 'canola' then
+        return
+      end
+      if not vim.b[args.buf].canola_ready then
         return
       end
       local ok, dir = pcall(require('canola').get_current_dir, args.buf)

--- a/spec/canola_git_spec.lua
+++ b/spec/canola_git_spec.lua
@@ -253,4 +253,212 @@ describe('canola-git', function()
       assert.is_nil(result)
     end)
   end)
+
+  describe('cache refresh and CanolaGitUpdate', function()
+    local tmpdir
+    local autocmds
+    local fired_events
+    local order
+    local system_outputs
+    local original_create_autocmd
+    local original_exec_autocmds
+    local original_system
+
+    local function has_event(event, expected)
+      if type(event) == 'table' then
+        return vim.tbl_contains(event, expected)
+      else
+        return event == expected
+      end
+    end
+
+    local function get_autocmd(expected_event, pattern)
+      for _, autocmd in ipairs(autocmds) do
+        if has_event(autocmd.event, expected_event) and autocmd.opts.pattern == pattern then
+          return autocmd.opts.callback
+        end
+      end
+    end
+
+    before_each(function()
+      tmpdir = vim.fn.tempname()
+      vim.fn.mkdir(tmpdir, 'p')
+      autocmds = {}
+      fired_events = {}
+      order = {}
+      system_outputs = {
+        ['git ls-files'] = {
+          code = 0,
+          stdout = table.concat({ 'sub/file.lua', 'old.lua', 'new.lua', 'conflict.lua' }, '\n'),
+        },
+        ['git ls-files --ignored --exclude-standard --others --directory'] = {
+          code = 0,
+          stdout = 'build/\n',
+        },
+        ['git status --porcelain -- .'] = {
+          code = 0,
+          stdout = table.concat({
+            ' M sub/file.lua',
+            'R  old.lua -> new.lua',
+            'UU conflict.lua',
+            '?? fresh.lua',
+          }, '\n'),
+        },
+      }
+
+      original_create_autocmd = vim.api.nvim_create_autocmd
+      original_exec_autocmds = vim.api.nvim_exec_autocmds
+      original_system = vim.system
+
+      vim.api.nvim_create_autocmd = function(event, opts)
+        table.insert(autocmds, { event = event, opts = opts })
+        return #autocmds
+      end
+
+      vim.api.nvim_exec_autocmds = function(event, opts)
+        table.insert(order, 'event')
+        table.insert(fired_events, { event = event, opts = opts })
+      end
+
+      vim.system = function(cmd, _opts, callback)
+        local key = table.concat(cmd, ' ')
+        local result = assert(system_outputs[key], key)
+        callback(result)
+        return {}
+      end
+
+      inject_mocks(make_canola_mock(tmpdir), make_git_mock(tmpdir), {
+        rerender_all_oil_buffers = function(_opts)
+          table.insert(order, 'rerender')
+        end,
+      })
+      canola_git = require('canola-git')
+      canola_git._init()
+    end)
+
+    after_each(function()
+      vim.api.nvim_create_autocmd = original_create_autocmd
+      vim.api.nvim_exec_autocmds = original_exec_autocmds
+      vim.system = original_system
+      if tmpdir then
+        vim.fn.delete(tmpdir, 'rf')
+      end
+    end)
+
+    it('stores raw path status data and emits CanolaGitUpdate before rerender', function()
+      local callback = assert(get_autocmd('User', 'CanolaReadPost'))
+      callback({ data = { buf = 1 } })
+
+      local cache = canola_git._cache[tmpdir]
+      assert.equals(tmpdir, cache.root)
+      assert.equals(' M', cache.status.sub)
+      assert.equals('R ', cache.status['new.lua'])
+      assert.is_true(cache.ignored.build)
+      assert.is_true(cache.tracked.sub)
+
+      assert.same({
+        status = ' M',
+        char = 'M',
+        type = 'modified',
+        index = nil,
+        worktree = 'M',
+        source_path = nil,
+      }, cache.path_status['sub/file.lua'])
+      assert.same({
+        status = 'R ',
+        char = 'R',
+        type = 'renamed',
+        index = 'R',
+        worktree = nil,
+        source_path = 'old.lua',
+      }, cache.path_status['new.lua'])
+      assert.same({
+        status = 'UU',
+        char = 'U',
+        type = 'unmerged',
+        index = 'U',
+        worktree = 'U',
+        source_path = nil,
+      }, cache.path_status['conflict.lua'])
+      assert.same({
+        status = '??',
+        char = '?',
+        type = 'untracked',
+        index = '?',
+        worktree = '?',
+        source_path = nil,
+      }, cache.path_status['fresh.lua'])
+
+      assert.equals('User', fired_events[1].event)
+      assert.equals('CanolaGitUpdate', fired_events[1].opts.pattern)
+      assert.same({ dir = tmpdir, root = tmpdir, reason = 'initial' }, fired_events[1].opts.data)
+      assert.same({ 'event', 'rerender' }, order)
+    end)
+
+    it('uses manual as the default invalidate reason', function()
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      vim.bo[bufnr].filetype = 'canola'
+
+      canola_git.invalidate()
+
+      assert.equals('CanolaGitUpdate', fired_events[1].opts.pattern)
+      assert.equals('manual', fired_events[1].opts.data.reason)
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+  end)
+
+  describe('non-git cache refresh', function()
+    local tmpdir
+    local autocmds
+    local fired_events
+    local original_create_autocmd
+    local original_exec_autocmds
+
+    local function get_autocmd(expected_event, pattern)
+      for _, autocmd in ipairs(autocmds) do
+        if autocmd.event == expected_event and autocmd.opts.pattern == pattern then
+          return autocmd.opts.callback
+        end
+      end
+    end
+
+    before_each(function()
+      tmpdir = vim.fn.tempname()
+      vim.fn.mkdir(tmpdir, 'p')
+      autocmds = {}
+      fired_events = {}
+
+      original_create_autocmd = vim.api.nvim_create_autocmd
+      original_exec_autocmds = vim.api.nvim_exec_autocmds
+
+      vim.api.nvim_create_autocmd = function(event, opts)
+        table.insert(autocmds, { event = event, opts = opts })
+        return #autocmds
+      end
+
+      vim.api.nvim_exec_autocmds = function(event, opts)
+        table.insert(fired_events, { event = event, opts = opts })
+      end
+
+      inject_mocks(make_canola_mock(tmpdir), make_git_mock(nil), make_view_mock())
+      canola_git = require('canola-git')
+      canola_git._init()
+    end)
+
+    after_each(function()
+      vim.api.nvim_create_autocmd = original_create_autocmd
+      vim.api.nvim_exec_autocmds = original_exec_autocmds
+      if tmpdir then
+        vim.fn.delete(tmpdir, 'rf')
+      end
+    end)
+
+    it('stores false and does not emit CanolaGitUpdate', function()
+      local callback = assert(get_autocmd('User', 'CanolaReadPost'))
+      callback({ data = { buf = 1 } })
+
+      assert.is_false(canola_git._cache[tmpdir])
+      assert.same({}, fired_events)
+    end)
+  end)
 end)

--- a/spec/canola_git_spec.lua
+++ b/spec/canola_git_spec.lua
@@ -262,7 +262,9 @@ describe('canola-git', function()
     local system_outputs
     local original_create_autocmd
     local original_exec_autocmds
+    local original_now
     local original_system
+    local fake_now
 
     local function has_event(event, expected)
       if type(event) == 'table' then
@@ -295,7 +297,7 @@ describe('canola-git', function()
           code = 0,
           stdout = 'build/\n',
         },
-        ['git status --porcelain -- .'] = {
+        ['git --no-optional-locks status --porcelain -- .'] = {
           code = 0,
           stdout = table.concat({
             ' M sub/file.lua',
@@ -308,7 +310,9 @@ describe('canola-git', function()
 
       original_create_autocmd = vim.api.nvim_create_autocmd
       original_exec_autocmds = vim.api.nvim_exec_autocmds
+      original_now = vim.uv.now
       original_system = vim.system
+      fake_now = 1000
 
       vim.api.nvim_create_autocmd = function(event, opts)
         table.insert(autocmds, { event = event, opts = opts })
@@ -318,6 +322,10 @@ describe('canola-git', function()
       vim.api.nvim_exec_autocmds = function(event, opts)
         table.insert(order, 'event')
         table.insert(fired_events, { event = event, opts = opts })
+      end
+
+      vim.uv.now = function()
+        return fake_now
       end
 
       vim.system = function(cmd, _opts, callback)
@@ -339,6 +347,7 @@ describe('canola-git', function()
     after_each(function()
       vim.api.nvim_create_autocmd = original_create_autocmd
       vim.api.nvim_exec_autocmds = original_exec_autocmds
+      vim.uv.now = original_now
       vim.system = original_system
       if tmpdir then
         vim.fn.delete(tmpdir, 'rf')
@@ -393,6 +402,46 @@ describe('canola-git', function()
       assert.equals('CanolaGitUpdate', fired_events[1].opts.pattern)
       assert.same({ dir = tmpdir, root = tmpdir, reason = 'initial' }, fired_events[1].opts.data)
       assert.same({ 'event', 'rerender' }, order)
+    end)
+
+    it('prefers initial over buf_enter before canola_ready', function()
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      local buf_enter = assert(get_autocmd('BufEnter'))
+      local read_post = assert(get_autocmd('User', 'CanolaReadPost'))
+
+      vim.bo[bufnr].filetype = 'canola'
+
+      buf_enter({ buf = bufnr })
+
+      assert.is_nil(canola_git._cache[tmpdir])
+      assert.same({}, fired_events)
+
+      read_post({ data = { buf = bufnr } })
+
+      assert.equals('initial', fired_events[1].opts.data.reason)
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('refreshes on buf_enter after canola_ready when cache is stale', function()
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      local buf_enter = assert(get_autocmd('BufEnter'))
+      local read_post = assert(get_autocmd('User', 'CanolaReadPost'))
+
+      vim.bo[bufnr].filetype = 'canola'
+
+      read_post({ data = { buf = bufnr } })
+
+      fired_events = {}
+      order = {}
+      vim.b[bufnr].canola_ready = true
+      fake_now = 4001
+
+      buf_enter({ buf = bufnr })
+
+      assert.equals('CanolaGitUpdate', fired_events[1].opts.pattern)
+      assert.equals('buf_enter', fired_events[1].opts.data.reason)
+      assert.same({ 'event', 'rerender' }, order)
+      vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
 
     it('uses manual as the default invalidate reason', function()


### PR DESCRIPTION
## Problem

Advanced canola-git recipes had no git-specific update hook, and the cache only retained the aggregated first-level status data needed for the built-in column. That made it awkward to react to git refreshes or inspect raw per-path porcelain state for custom recipes.

## Solution

Emit a `CanolaGitUpdate` user autocmd after each canola-git cache refresh, with a small payload containing the refreshed directory, repo root, and refresh reason. Expand `_cache[dir]` to retain raw per-path status data alongside the existing aggregated status table, keep `get_status()` behavior unchanged, and document concise recipes for the new event and advanced cache inspection.