### PR TITLE
fix(canola-git): preserve git_status column width in clean repos

### DIFF
--- a/lua/canola-git/init.lua
+++ b/lua/canola-git/init.lua
@@ -453,6 +453,25 @@ end
 
 M._init = function()
   require('canola.columns').register('git_status', {
+    all_empty_width = function(_, bufnr)
+      local canola = require('canola')
+      local dir = canola.get_current_dir(bufnr)
+      if not dir then
+        return nil
+      end
+      local cache = M._cache[dir]
+      if cache == false then
+        return nil
+      end
+      if not cache and not require('canola.git').get_root(dir) then
+        return nil
+      end
+      if get_config().format == 'porcelain' then
+        return 2
+      else
+        return 1
+      end
+    end,
     render = function(entry, conf, bufnr)
       local name = entry[require('canola.constants').FIELD_NAME]
       local dir = require('canola').get_current_dir(bufnr)

--- a/spec/canola_git_spec.lua
+++ b/spec/canola_git_spec.lua
@@ -214,11 +214,13 @@ describe('canola-git', function()
 
   describe('git_status column render', function()
     local render_fn
+    local all_empty_width_fn
 
     before_each(function()
       local columns_mock = {
         register = function(_name, def)
           render_fn = def.render
+          all_empty_width_fn = def.all_empty_width
         end,
       }
       package.loaded['canola'] = make_canola_mock('/repo')
@@ -251,6 +253,23 @@ describe('canola-git', function()
       canola_git._cache = { ['/repo'] = { status = {}, tracked = {}, ignored = {} } }
       local result = render_fn({ nil, 'clean.lua' }, {}, 0)
       assert.is_nil(result)
+    end)
+
+    it('reserves compact width for git repos without visible status', function()
+      assert.equals(1, all_empty_width_fn({}, 0))
+    end)
+
+    it('reserves porcelain width for git repos without visible status', function()
+      vim.g.canola_git = { format = 'porcelain' }
+      assert.equals(2, all_empty_width_fn({}, 0))
+    end)
+
+    it('returns nil width for non-git directories', function()
+      package.loaded['canola.git'] = make_git_mock(nil)
+      package.loaded['canola-git'] = nil
+      canola_git = require('canola-git')
+      canola_git._init()
+      assert.is_nil(all_empty_width_fn({}, 0))
     end)
   end)
 


### PR DESCRIPTION
## Problem

The git_status column currently collapses entirely when a repository is clean or when no visible entries have a git status. That makes the listing shift horizontally as repositories move between clean and dirty states.

## Solution

Opt git_status into canola.nvim's all_empty_width hook so it reserves width 1 in compact and symbol modes and width 2 in porcelain mode whenever the current directory is part of a git repository. Non-git directories still collapse the column entirely, and the new behavior is covered with focused canola-git tests.

closes #39 