### PR TITLE
ci: replace prettier with biome

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,9 +9,10 @@ repos:
         files: \.lua$
         pass_filenames: true
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/biomejs/pre-commit
+    rev: v0.6.1
     hooks:
-      - id: prettier
-        name: prettier
-        files: \.(md|toml|yaml|yml|sh)$
+      - id: biome-format
+        name: biome format
+        additional_dependencies:
+          - '@biomejs/biome@2.4.11'

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,0 @@
-{
-  "proseWrap": "always",
-  "printWidth": 80,
-  "tabWidth": 2,
-  "useTabs": false,
-  "trailingComma": "none",
-  "semi": false,
-  "singleQuote": true
-}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 80,
+    "useEditorconfig": true
+  },
+  "linter": {
+    "enabled": false
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "none",
+      "semicolons": "asNeeded"
+    }
+  },
+  "assist": {
+    "enabled": false
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
         pkgs:
         let
           commonPackages = [
-            pkgs.prettier
+            pkgs.biome
             pkgs.stylua
             pkgs.selene
             pkgs.lua-language-server

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ default:
 format:
     nix fmt -- --ci
     stylua --check .
-    prettier --check .
+    biome check .
 
 lint:
     git ls-files '*.lua' | xargs selene --display-style quiet


### PR DESCRIPTION
## Problem

The repo still depended on Prettier in the dev shell, `just format`, and pre-commit, so formatting checks were split across two tools.

## Solution

Replace the Prettier dependency and hook with Biome, add a repo Biome config for the supported files it formats here, and remove the old Prettier config files.