### PR TITLE
fix(canola-git): normalize relprefix to unix filepaths

### DIFF
--- a/lua/canola-git/init.lua
+++ b/lua/canola-git/init.lua
@@ -300,7 +300,7 @@ local function populate_cache(dir, reason)
     return
   end
   pcall(start_watcher, root)
-  local relprefix = dir:sub(#root + 1):gsub('^/', '')
+  local relprefix = dir:gsub('\\', '/'):sub(#root + 1):gsub('^/', '')
   if relprefix ~= '' and relprefix:sub(-1) ~= '/' then
     relprefix = relprefix .. '/'
   end


### PR DESCRIPTION
## Problem
All git signs *not* at the git root directory never appear when using windows.

## Cause
Windows paths use `'\\'` rather than `'/'`. The `relprefix` usages in `populate_cache` require `'/'`. When it tries to get deeper relative paths, it fails to match the path and normalize, causing the cached status keys to always match the first component from the git root level.

## Minimal Cache Example

The following examples are based off the git porcelain cmd returning ` M lua/canola-git/init.lua`.

### Good (current):

```lua
{
  ["C:\\...\\canola-collection\\"] = {
    status = {
      lua = " M"
    },
  },
  ["C:\\...\\canola-collection\\lua\\"] = {
    status = {
      ["canola-git"] = " M"
    },
  },
  ["C:\\...\\canola-collection\\lua\\canola-git\\"] = {
    status = {
      ["init.lua"] = " M"},
    }
  }
}
```

### Bad (previous):

```lua
{
  ["C:\\...\\canola-collection\\"] = {
    status = {
      lua = " M"
    },
  },
  ["C:\\...\\canola-collection\\lua\\"] = {
    status = {
      lua = " M"
    },
  },
  ["C:\\...\\canola-collection\\lua\\canola-git\\"] = {
    status = {
      lua = " M"
    }
  }
}
```

## Solution
This commit replaces all `'\\'` with `'/'` if they exist in the dir path when creating the `relprefix`.
```lua
-- function populate_cache(...)
local relprefix = dir:gsub('\\', '/') -- rest as before ...
```

**Note:** Performing `gsub` on `dir` at the start of the function may have other side effects on windows, so I kept this local to the `relprefix` declaration. No issues so far.